### PR TITLE
Airbrake/Errbit projecy env var wrong name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module WasteCarriersFrontOffice
     # the project ID, but it still has to be set to a positive integer or
     # Airbrake errors. Hence we just set it to 1.
     config.airbrake_id = 1
-    config.airbrake_key = ENV["WCRS_RENEWALS_AIRBRAKE_PROJECT_KEY"] || "dummy"
+    config.airbrake_key = ENV["WCRS_FRONTOFFICE_AIRBRAKE_PROJECT_KEY"] || "dummy"
 
     # Companies House config
     config.companies_house_host = ENV["WCRS_COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"


### PR DESCRIPTION
The name of the env var which holds the Airbrake/Errbit project key for this app was incorrect.

This change fixes that.