### PR TITLE
Add Passenger web app server to project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,13 @@ gem "high_voltage", "~> 3.0"
 
 gem "secure_headers", "~> 5.0"
 
+# Web application server that replaces webrick. It handles HTTP requests,
+# manages processes and resources, and enables administration, monitoring
+# and problem diagnosis. It is used in production because it gives us an ability
+# to scale by creating additional processes, and will automatically restart any
+# that fail.
+gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler"
+
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,9 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
+    passenger (5.3.3)
+      rack
+      rake (>= 0.8.1)
     phonelib (0.6.22)
     powerpack (0.1.2)
     public_suffix (3.0.2)
@@ -328,6 +331,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   mongoid (~> 5.2.0)
+  passenger (~> 5.0, >= 5.0.30)
   rails (= 4.2.10)
   rspec-rails (~> 3.6)
   rubocop

--- a/lib/tasks/passenger.rake
+++ b/lib/tasks/passenger.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :passenger do
+  desc "Restart all processes"
+  task restart: :environment do
+    sh "bundle exec passenger-config restart-app --ignore-passenger-not-running /"
+  end
+
+  desc "Enable auto restart after each request"
+  task enable_restart: :environment do
+    sh "touch tmp/always_restart.txt"
+  end
+
+  desc "Disable auto restart after each request"
+  task disable_restart: :environment do
+    sh "rm tmp/always_restart.txt"
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-161

In production we use Passenger as our web application server, as Webrick is not suitable for production deployments.

Passenger as a web application server will handle the HTTP requests, but also manage all processes and resources, and enables administration, monitoring and problem diagnosis. It is used in production because it gives us an ability to scale by creating additional processes, and will automatically restart any that fail.

This change adds it to the project, in such a way that all future calls to `bundle exec rails s` will actually cause Passenger to start and create an instance of the app in a process, rather than firing up webrick.

Because of this and the way processes are isolated they will not automatically pick up code changes. Therefore we also add some rake helper tasks to allow the team to quickly restart all processes and enable/disable Passengers auto-restart option (<https://www.phusionpassenger.com/library/walkthroughs/basics/ruby/reloading_code.html#tmp-always_restart-txt>)