### PR TITLE
Fix seeding after field renaming

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 38dd85a7363547a4c5b7e3a04b3c59f02f9f5817
+  revision: 047a7c4946c5da60e0e912eabebe3e10f61702a4
   branch: master
   specs:
     waste_carriers_engine (0.0.1)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,10 +27,10 @@ def parse_dates(seed, date)
   seed["metaData"]["dateRegistered"] = date
   seed["metaData"]["lastModified"] = date
   seed["metaData"]["dateActivated"] = date
-  seed["convictionSearchResult"]["searchedAt"] = date
+  seed["conviction_search_result"]["searched_at"] = date
   seed["expires_on"] = date + 3.years
-  seed["keyPeople"].each do |key_person|
-    key_person["convictionSearchResult"]["searchedAt"] = date
+  seed["key_people"].each do |key_person|
+    key_person["conviction_search_result"]["searched_at"] = date
   end
 end
 

--- a/db/seeds/CBDU200.json
+++ b/db/seeds/CBDU200.json
@@ -36,25 +36,25 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+  "key_people": [{
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     },
     {
-      "firstName": "Another",
-      "lastName": "Employee",
-      "dateOfBirth": "1968-01-01",
+      "first_name": "Another",
+      "last_name": "Employee",
+      "dob": "1968-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -69,8 +69,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU201.json
+++ b/db/seeds/CBDU201.json
@@ -38,15 +38,15 @@
       "country": "Brazil"
     }
   ],
-  "keyPeople": [
+  "key_people": [
     {
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Director",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -61,8 +61,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU202.json
+++ b/db/seeds/CBDU202.json
@@ -38,15 +38,15 @@
       "country": "Brazil"
     }
   ],
-  "keyPeople": [
+  "key_people": [
     {
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Director",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -61,8 +61,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU203.json
+++ b/db/seeds/CBDU203.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU204.json
+++ b/db/seeds/CBDU204.json
@@ -36,25 +36,25 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+  "key_people": [{
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     },
     {
-      "firstName": "Another",
-      "lastName": "Employee",
-      "dateOfBirth": "1968-01-01",
+      "first_name": "Another",
+      "last_name": "Employee",
+      "dob": "1968-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -69,8 +69,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU205.json
+++ b/db/seeds/CBDU205.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -58,8 +58,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU205.json
+++ b/db/seeds/CBDU205.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU206.json
+++ b/db/seeds/CBDU206.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -58,8 +58,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU206.json
+++ b/db/seeds/CBDU206.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU207.json
+++ b/db/seeds/CBDU207.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "946107",
+  "company_no": "946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU207.json
+++ b/db/seeds/CBDU207.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -58,8 +58,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU208.json
+++ b/db/seeds/CBDU208.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU209.json
+++ b/db/seeds/CBDU209.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU210.json
+++ b/db/seeds/CBDU210.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU211.json
+++ b/db/seeds/CBDU211.json
@@ -36,25 +36,25 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+  "key_people": [{
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     },
     {
-      "firstName": "Another",
-      "lastName": "Employee",
-      "dateOfBirth": "1968-01-01",
+      "first_name": "Another",
+      "last_name": "Employee",
+      "dob": "1968-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -69,8 +69,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU212.json
+++ b/db/seeds/CBDU212.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -59,8 +59,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU212.json
+++ b/db/seeds/CBDU212.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU213.json
+++ b/db/seeds/CBDU213.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -59,8 +59,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU213.json
+++ b/db/seeds/CBDU213.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU214.json
+++ b/db/seeds/CBDU214.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Liability Partnership Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU214.json
+++ b/db/seeds/CBDU214.json
@@ -37,25 +37,25 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+  "key_people": [{
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     },
     {
-      "firstName": "Another",
-      "lastName": "Employee",
-      "dateOfBirth": "1968-01-01",
+      "first_name": "Another",
+      "last_name": "Employee",
+      "dob": "1968-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -70,8 +70,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU215.json
+++ b/db/seeds/CBDU215.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "946107",
+  "company_no": "946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU215.json
+++ b/db/seeds/CBDU215.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -58,8 +58,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU216.json
+++ b/db/seeds/CBDU216.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -59,8 +59,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU216.json
+++ b/db/seeds/CBDU216.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU217.json
+++ b/db/seeds/CBDU217.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU218.json
+++ b/db/seeds/CBDU218.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU219.json
+++ b/db/seeds/CBDU219.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU220.json
+++ b/db/seeds/CBDU220.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU221.json
+++ b/db/seeds/CBDU221.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -59,8 +59,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU221.json
+++ b/db/seeds/CBDU221.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Company Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU222.json
+++ b/db/seeds/CBDU222.json
@@ -37,14 +37,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -59,8 +59,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU222.json
+++ b/db/seeds/CBDU222.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Waste Not Want Not, UK",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU223.json
+++ b/db/seeds/CBDU223.json
@@ -36,25 +36,25 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+  "key_people": [{
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     },
     {
-      "firstName": "Another",
-      "lastName": "Employee",
-      "dateOfBirth": "1968-01-01",
+      "first_name": "Another",
+      "last_name": "Employee",
+      "dob": "1968-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -69,8 +69,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU224.json
+++ b/db/seeds/CBDU224.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU225.json
+++ b/db/seeds/CBDU225.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU226.json
+++ b/db/seeds/CBDU226.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Director",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU227.json
+++ b/db/seeds/CBDU227.json
@@ -7,7 +7,7 @@
   "isMainService": "yes",
   "onlyAMF": "no",
   "companyName": "Limited Liability Partnership Seed",
-  "companyNo": "00946107",
+  "company_no": "00946107",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/db/seeds/CBDU227.json
+++ b/db/seeds/CBDU227.json
@@ -37,25 +37,25 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-      "firstName": "Test",
-      "lastName": "Employee",
-      "dateOfBirth": "1978-01-01",
+  "key_people": [{
+      "first_name": "Test",
+      "last_name": "Employee",
+      "dob": "1978-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     },
     {
-      "firstName": "Another",
-      "lastName": "Employee",
-      "dateOfBirth": "1968-01-01",
+      "first_name": "Another",
+      "last_name": "Employee",
+      "dob": "1968-01-01",
       "position": "Partner",
-      "personType": "KEY",
-      "convictionSearchResult": {
-        "matchResult": "NO",
+      "person_type": "KEY",
+      "conviction_search_result": {
+        "match_result": "NO",
         "confirmed": "no"
       }
     }
@@ -70,8 +70,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU228.json
+++ b/db/seeds/CBDU228.json
@@ -36,14 +36,14 @@
       "country": ""
     }
   ],
-  "keyPeople": [{
-    "firstName": "Test",
-    "lastName": "Employee",
-    "dateOfBirth": "1978-01-01",
+  "key_people": [{
+    "first_name": "Test",
+    "last_name": "Employee",
+    "dob": "1978-01-01",
     "position": "Partner",
-    "personType": "KEY",
-    "convictionSearchResult": {
-      "matchResult": "NO",
+    "person_type": "KEY",
+    "conviction_search_result": {
+      "match_result": "NO",
       "confirmed": "no"
     }
   }],
@@ -57,8 +57,8 @@
     "route": "DIGITAL",
     "distance": "n/a"
   },
-  "convictionSearchResult": {
-    "matchResult": "NO",
+  "conviction_search_result": {
+    "match_result": "NO",
     "confirmed": "no"
   }
 }


### PR DESCRIPTION
We renamed some fields from camelCase to snake_case after the Java 8 upgrade on waste-carriers-service. Now that the model has been updated, the seeds need to be modified too.