### PR TITLE
Move users out of engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,13 @@ gem "uglifier", ">= 1.3.0"
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc
 
+# Use CanCanCan for user roles and permissions
+# Version 2.0 doesn't support Mongoid, so we're locked to an earlier one
+gem "cancancan", "~> 1.10"
+
+# Use Devise for user authentication
+gem "devise", ">= 4.4.3"
+
 # GOV.UK styling
 gem "govuk_elements_rails", "~> 3.1"
 gem "govuk_template", "~> 0.23"
@@ -46,7 +53,7 @@ gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",
-    branch: "master"
+    branch: "feature/move-users-out-of-engine"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",
-    branch: "feature/move-users-out-of-engine"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 9272db62176be8c4dbca7bcc10b519383e5e65a0
-  branch: feature/move-users-out-of-engine
+  revision: d8b657683f37cbfcf23e216b6fe3c3f5d863c920
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
@@ -350,4 +350,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,11 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: cf3d8ceb2dd2e65247ba49784219b40eb515728a
-  branch: master
+  revision: 9272db62176be8c4dbca7bcc10b519383e5e65a0
+  branch: feature/move-users-out-of-engine
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
-      cancancan (~> 1.10)
       countries
-      devise (>= 4.4.3)
       high_voltage (~> 3.0)
       jbuilder (~> 2.0)
       jquery-rails
@@ -321,8 +319,10 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 5.8.1)
   byebug
+  cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   database_cleaner
+  devise (>= 4.4.3)
   dotenv-rails
   factory_bot_rails
   github_changelog_generator

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  helper WasteCarriersEngine::ApplicationHelper
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Ability
   include CanCan::Ability
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,8 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :read, WasteCarriersEngine::Registration, account_email: user.email
+    can :manage, WasteCarriersEngine::TransientRegistration, account_email: user.email
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User
   include Mongoid::Document
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,49 @@
+class User
+  include Mongoid::Document
+
+  # Use the User database
+  store_in client: "users", collection: "users"
+
+  devise :database_authenticatable,
+         :lockable,
+         :recoverable,
+         :trackable,
+         :validatable
+
+  ## Confirmable
+  # Any user confirmation happens in the frontend app - however we need this flag to seed confirmed users
+  field :confirmed_at, type: DateTime
+
+  ## Database authenticatable
+  field :email,              type: String, default: ""
+  field :encrypted_password, type: String, default: ""
+
+  ## Recoverable
+  field :reset_password_token,   type: String
+  field :reset_password_sent_at, type: Time
+
+  ## Trackable
+  field :sign_in_count,      type: Integer, default: 0
+  field :current_sign_in_at, type: Time
+  field :last_sign_in_at,    type: Time
+  field :current_sign_in_ip, type: String
+  field :last_sign_in_ip,    type: String
+
+  # Lockable
+  field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts
+  field :unlock_token,    type: String # Only if unlock strategy is :email or :both
+  field :locked_at,       type: Time
+
+  validates :password, presence: true, length: { in: 8..128 }
+  validate :password_must_have_lowercase_uppercase_and_numeric
+
+  private
+
+  def password_must_have_lowercase_uppercase_and_numeric
+    has_lowercase = (password =~ /[a-z]/)
+    has_uppercase = (password =~ /[A-Z]/)
+    has_numeric = (password =~ /[0-9]/)
+    return true if has_lowercase && has_uppercase && has_numeric
+    errors.add(:password, I18n.t("errors.messages.weakPassword"))
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,277 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = 'a04ec6d98a19eda57e8f7088e424cb94702810715afc2bf80028cdc42bf359862dc15470ec8cb71d44e476c2df15262e724595935d01aa8493c878e3b903f7bd'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = '"Waste Carriers Service" <registrations@wastecarriersregistration.service.gov.uk>'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/mongoid'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 10
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '88542cafd6aa8411a0e900eb961ba8a865d3745108d873ddecc3056d32f79299606810915d7dc71bd96422892a1d4ca6612acf2e1129eabbf45988255edb0f47'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  config.confirm_within = 24.hours
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 8..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  config.maximum_attempts = 10
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  config.unlock_in = 30.minutes
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :get
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,9 @@ Rails.application.routes.draw do
   mount WasteCarriersEngine::Engine => "/"
 
   root "waste_carriers_engine/registrations#index"
+
+  devise_for :users
+  devise_scope :user do
+    get "/users/sign_out" => "devise/sessions#destroy"
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,7 +39,7 @@ def seed_users
   users = seeds["users"]
 
   users.each do |user|
-    WasteCarriersEngine::User.find_or_create_by(
+    User.find_or_create_by(
       email: user["email"],
       password: ENV["WCRS_DEFAULT_PASSWORD"] || "Secret123",
       confirmed_at: Time.new(2015, 1, 1)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
     sequence :email do |n|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    sequence :email do |n|
+      "user#{n}@example.com"
+    end
+
+    password "Secret123"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe User, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "#password" do
+    context "when the user's password meets the requirements" do
+      let(:user) { build(:user, password: "Secret123") }
+
+      it "should be valid" do
+        expect(user).to be_valid
+      end
+    end
+
+    context "when the user's password is blank" do
+      let(:user) { build(:user, password: "") }
+
+      it "should not be valid" do
+        expect(user).to_not be_valid
+      end
+    end
+
+    context "when the user's password has no lowercase letters" do
+      let(:user) { build(:user, password: "SECRET123") }
+
+      it "should not be valid" do
+        expect(user).to_not be_valid
+      end
+    end
+
+    context "when the user's password has no uppercase letters" do
+      let(:user) { build(:user, password: "secret123") }
+
+      it "should not be valid" do
+        expect(user).to_not be_valid
+      end
+    end
+
+    context "when the user's password has no numbers" do
+      let(:user) { build(:user, password: "SuperSecret") }
+
+      it "should not be valid" do
+        expect(user).to_not be_valid
+      end
+    end
+
+    context "when the user's password is too short" do
+      let(:user) { build(:user, password: "Sec123") }
+
+      it "should not be valid" do
+        expect(user).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require "rspec/rails"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
-  config.include RequestSpecHelper, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Sessions", type: :request do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /users/sign_in" do
+    context "when a user is not signed in" do
+      it "returns a success response" do
+        get new_user_session_path
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe "POST /users/sign_in" do
+    context "when a user is not signed in" do
+      context "when valid user details are submitted" do
+        let(:user) { create(:user) }
+
+        it "signs the user in" do
+          post user_session_path, user: { email: user.email, password: user.password }
+          expect(controller.current_user).to eq(user)
+        end
+
+        it "returns a 302 response" do
+          post user_session_path, user: { email: user.email, password: user.password }
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the root path" do
+          post user_session_path, user: { email: user.email, password: user.password }
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
+  end
+
+  describe "DELETE /users/sign_out" do
+    context "when the user is signed in" do
+      before(:each) do
+        user = create(:user)
+        sign_in(user)
+      end
+
+      it "signs the user out" do
+        get destroy_user_session_path
+        expect(controller.current_user).to be_nil
+      end
+
+      it "returns a 302 response" do
+        get destroy_user_session_path
+        expect(response).to have_http_status(302)
+      end
+
+      it "redirects to the root path" do
+        get destroy_user_session_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
When we first set up the engine, we included users and related functionality like Devise and CanCanCan. However, it's become clear that the front office and back office users are sufficiently different that we shouldn't be trying to tackle this in the engine and should let the host apps handle it instead.

This PR re-implements the user functionality (including Devise and CanCanCan) which was removed from the engine in DEFRA/waste-carriers-renewals#228