### PR TITLE
Mount renewals engine in a directory, not root

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,7 @@
 Rails.application.routes.draw do
-  mount WasteCarriersEngine::Engine => "/"
+  mount WasteCarriersEngine::Engine => "/fo"
 
   root "waste_carriers_engine/registrations#index"
 
-  devise_for :users
-  devise_scope :user do
-    get "/users/sign_out" => "devise/sessions#destroy"
-  end
+  devise_for :users, path: "/fo/users", path_names: { sign_in: "sign_in", sign_out: "sign_out" }
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-427

Currently the waste-carriers-front-office mounts the renewals engine at root. (For example, /renew/CBDU1234).

The new and existing applications will be accessed through the same domain. Determining which requests should go to which applications. This is a lot easier to do if the routes are similar. Mounting the journey within a directory (eg /fo/renew/CBDU1234) means we can cover the whole engine with a single line (eg /fo/*) rather than specifying every single route, which would be time-consuming to set up and maintain.

This change should cover the Devise paths as well.