### PR TITLE
Set the host in application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,7 @@ module WasteCarriersFrontOffice
     config.wcrs_frontend_url = ENV["WCRS_FRONTEND_DOMAIN"] || "http://localhost:3000"
     config.wcrs_services_url = ENV["WCRS_SERVICES_DOMAIN"] || "http://localhost:8003"
     config.os_places_service_url = ENV["WCRS_OS_PLACES_DOMAIN"] || "http://localhost:8005"
+    config.host = config.wcrs_renewals_url
 
     # Fees
     config.renewal_charge = ENV["WCRS_RENEWAL_CHARGE"].to_i


### PR DESCRIPTION
This is to improve the way we generate WorldPay success and failure URLs in the engine. See https://github.com/DEFRA/waste-carriers-renewals/pull/231