### PR TITLE
Fix broken footer links

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <%= t(".support_text") %>
   </p>
   <ul>
-    <li class="inline"><%= link_to 'Privacy', "/privacy",  target: "_blank" %></li>
-    <li class="inline"><%= link_to 'Cookies', "/cookies",  target: "_blank" %></li>
+    <li class="inline"><%= link_to 'Privacy', page_path("privacy"),  target: "_blank" %></li>
+    <li class="inline"><%= link_to 'Cookies', page_path("cookies"),  target: "_blank" %></li>
   </ul>
 </div>


### PR DESCRIPTION
Fix links to privacy and cookies policies by using the High Voltage path helper instead of hard-coding the paths.