### PR TITLE
Raise translation errors when running tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,5 +38,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
If a test encounters a missing translation error, we want to know about it.