### PR TITLE
Change seed email addresses

### DIFF
--- a/db/seeds/CBDU200.json
+++ b/db/seeds/CBDU200.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -59,7 +59,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU200",

--- a/db/seeds/CBDU201.json
+++ b/db/seeds/CBDU201.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [
     {
       "addressType": "REGISTERED",
@@ -51,7 +51,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU201",

--- a/db/seeds/CBDU202.json
+++ b/db/seeds/CBDU202.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [
     {
       "addressType": "REGISTERED",
@@ -51,7 +51,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU202",

--- a/db/seeds/CBDU203.json
+++ b/db/seeds/CBDU203.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU203",

--- a/db/seeds/CBDU204.json
+++ b/db/seeds/CBDU204.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -59,7 +59,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU204",

--- a/db/seeds/CBDU205.json
+++ b/db/seeds/CBDU205.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU205",

--- a/db/seeds/CBDU206.json
+++ b/db/seeds/CBDU206.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU206",

--- a/db/seeds/CBDU207.json
+++ b/db/seeds/CBDU207.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU207",

--- a/db/seeds/CBDU208.json
+++ b/db/seeds/CBDU208.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU208",

--- a/db/seeds/CBDU209.json
+++ b/db/seeds/CBDU209.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU209",

--- a/db/seeds/CBDU210.json
+++ b/db/seeds/CBDU210.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU210",

--- a/db/seeds/CBDU211.json
+++ b/db/seeds/CBDU211.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -59,7 +59,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU211",

--- a/db/seeds/CBDU212.json
+++ b/db/seeds/CBDU212.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU212",

--- a/db/seeds/CBDU213.json
+++ b/db/seeds/CBDU213.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "another-user@waste-exemplar.gov.uk",
+  "contactEmail": "another-user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "another-user@waste-exemplar.gov.uk",
+  "accountEmail": "another-user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU213",

--- a/db/seeds/CBDU214.json
+++ b/db/seeds/CBDU214.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -60,7 +60,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU214",

--- a/db/seeds/CBDU215.json
+++ b/db/seeds/CBDU215.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU215",

--- a/db/seeds/CBDU216.json
+++ b/db/seeds/CBDU216.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU216",

--- a/db/seeds/CBDU217.json
+++ b/db/seeds/CBDU217.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU217",

--- a/db/seeds/CBDU218.json
+++ b/db/seeds/CBDU218.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU218",

--- a/db/seeds/CBDU219.json
+++ b/db/seeds/CBDU219.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU219",

--- a/db/seeds/CBDU220.json
+++ b/db/seeds/CBDU220.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU220",

--- a/db/seeds/CBDU221.json
+++ b/db/seeds/CBDU221.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU221",

--- a/db/seeds/CBDU222.json
+++ b/db/seeds/CBDU222.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU222",

--- a/db/seeds/CBDU223.json
+++ b/db/seeds/CBDU223.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -59,7 +59,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU223",

--- a/db/seeds/CBDU224.json
+++ b/db/seeds/CBDU224.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU224",

--- a/db/seeds/CBDU225.json
+++ b/db/seeds/CBDU225.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU225",

--- a/db/seeds/CBDU226.json
+++ b/db/seeds/CBDU226.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU226",

--- a/db/seeds/CBDU227.json
+++ b/db/seeds/CBDU227.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -60,7 +60,7 @@
       }
     }
   ],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU227",

--- a/db/seeds/CBDU228.json
+++ b/db/seeds/CBDU228.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@waste-exemplar.gov.uk",
+  "contactEmail": "user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@waste-exemplar.gov.uk",
+  "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU228",

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -1,10 +1,10 @@
 {
   "users": [
     {
-      "email": "user@waste-exemplar.gov.uk"
+      "email": "user@example.com"
     },
     {
-      "email": "another-user@waste-exemplar.gov.uk"
+      "email": "another-user@example.com"
     }
   ]
 }


### PR DESCRIPTION
Instead of @waste-exemplar.gov.uk, we use @example.com to show that these won't be government users.