### PR TITLE
Update deprecated static attributes in factories

### DIFF
--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -2,18 +2,18 @@
 
 FactoryBot.define do
   factory :address, class: WasteCarriersEngine::Address do
-    house_number "42"
-    address_line_1 "Foo Gardens"
-    town_city "Baz City"
-    postcode "FA1 1KE"
-    uprn "340116"
+    house_number { "42" }
+    address_line_1 { "Foo Gardens" }
+    town_city { "Baz City" }
+    postcode { "FA1 1KE" }
+    uprn { "340116" }
 
     trait :contact do
-      address_type "POSTAL"
+      address_type { "POSTAL" }
     end
 
     trait :registered do
-      address_type "REGISTERED"
+      address_type { "REGISTERED" }
     end
   end
 end

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :metaData, class: WasteCarriersEngine::MetaData do
-    date_registered Time.current
+    date_registered { Time.current }
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :registration, class: WasteCarriersEngine::Registration do
-    tier "UPPER"
+    tier { "UPPER" }
 
     addresses { [build(:address), build(:address)] }
 
@@ -10,7 +10,7 @@ FactoryBot.define do
 
     trait :expires_soon do
       metaData { build(:metaData, status: :ACTIVE) }
-      expires_on 2.months.from_now
+      expires_on { 2.months.from_now }
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
       "user#{n}@example.com"
     end
 
-    password "Secret123"
+    password { "Secret123" }
   end
 end


### PR DESCRIPTION
factory_bot 4.11.0 deprecates static attributes, which will be removed in v5. This meant that when we ran our test suite, we got a huge number of deprecation warnings. For example:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

expires_on { Fri, 21 Aug 2020 10:11:31 UTC +00:00 }
```

So this commit does exactly that.

For more info, see: https://github.com/thoughtbot/factory_bot/releases/tag/v4.11.0