### PR TITLE
Test converting active upper tier regs to transient objects

### DIFF
--- a/lib/tasks/create_transient_registrations.rake
+++ b/lib/tasks/create_transient_registrations.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# require "waste_carriers_engine"
+
+desc "Attempt to create transient_registrations in the database from all active, upper-tier registrations"
+task create_transient_registrations: :environment do
+  log_path = "log/create_transient_registrations_#{Time.current.to_i}.log"
+  log = ActiveSupport::Logger.new(log_path)
+
+  print "Finding all active upper-tier registrations..."
+
+  registrations = WasteCarriersEngine::Registration.where(tier: "UPPER", "metaData.status": "ACTIVE")
+
+  puts " #{registrations.count} matching registrations found.\n\n"
+
+  error_count = 0
+
+  registrations.each do |registration|
+    reg_identifier = registration.reg_identifier
+    print "  creating transient_registration for #{reg_identifier}..."
+
+    begin
+      transient_registration = WasteCarriersEngine::TransientRegistration.new(reg_identifier: reg_identifier)
+      transient_registration.save!
+      puts " ✓"
+    rescue StandardError => e
+      puts " ERROR"
+      error_count += 1
+
+      log.info "\n----------"
+      log.info "#{reg_identifier} - attempt to create transient_registration failed"
+      log.info e.to_s
+    end
+  end
+
+  puts "\nAttempted creation of #{registrations.count} transient_registrations complete"
+  puts "Errors: #{error_count}"
+  puts "Details saved to #{log_path}"
+end

--- a/lib/tasks/create_transient_registrations.rake
+++ b/lib/tasks/create_transient_registrations.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# require "waste_carriers_engine"
-
 desc "Attempt to create transient_registrations in the database from all active, upper-tier registrations"
 task create_transient_registrations: :environment do
   log_path = "log/create_transient_registrations_#{Time.current.to_i}.log"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-145

As part of the design of the new renewals service, when a user comes to renew their registration we take the existing record and generate a transient_registration (a new record) from it.

This is so they can update their details during the renewal process without affecting the existing registration, and retain their existing reg number. Once the process is complete, the transient object switches to being their renewed registration.

However, due to the less structured nature of the database, we cannot assume that all existing upper tier registrations have all the fields, properties and sub documents we might expect. Therefore we need a mechanism to test the conversion from a registration to a transient_registration to ensure it can handle existing registrations.