### PR TITLE
Fix reg to trans test to override Mongo timeout

### DIFF
--- a/lib/tasks/create_transient_registrations.rake
+++ b/lib/tasks/create_transient_registrations.rake
@@ -5,25 +5,66 @@ task create_transient_registrations: :environment do
   log_path = "log/create_transient_registrations_#{Time.current.to_i}.log"
   log = ActiveSupport::Logger.new(log_path)
 
+  counts = {
+    total: 0,
+    success: 0,
+    error: 0
+  }
+  counts[:total] = renewable_registrations.count
+
+  paging = {
+    page_size: 1000,
+    page_number: 1,
+    num_of_pages: (counts[:total] / 1000).ceil
+  }
+
   print "Finding all active upper-tier registrations..."
+  puts " #{counts[:total]} matching registrations found.\n\n"
 
-  registrations = WasteCarriersEngine::Registration.where(tier: "UPPER", "metaData.status": "ACTIVE")
+  counts = page_through_registrations(paging, counts, log)
 
-  puts " #{registrations.count} matching registrations found.\n\n"
+  puts "\nAttempted creation of #{counts[:total]} transient_registrations complete"
+  puts "Errors: #{counts[:error]}"
+  puts "Successes: #{counts[:success]}"
+  puts "Details saved to #{log_path}"
+end
 
-  error_count = 0
+def registrations_collection
+  Mongoid::Clients.default.database.collections.find { |c| c.name == "registrations" }
+end
 
+def renewable_registrations
+  registrations_collection.find(tier: "UPPER", "metaData.status": "ACTIVE").no_cursor_timeout
+end
+
+def paged_renewable_registrations(paging)
+  registrations_collection
+    .find(tier: "UPPER", "metaData.status": "ACTIVE")
+    .skip(paging[:page_size] * (paging[:page_number] - 1))
+    .limit(paging[:page_size])
+end
+
+def page_through_registrations(paging, counts, log)
+  while paging[:page_number] <= paging[:num_of_pages]
+    counts = test_registrations(paged_renewable_registrations(paging), counts, log)
+    paging[:page_number] += 1
+  end
+  counts
+end
+
+def test_registrations(registrations, counts, log)
   registrations.each do |registration|
-    reg_identifier = registration.reg_identifier
+    reg_identifier = registration["regIdentifier"]
     print "  creating transient_registration for #{reg_identifier}..."
 
     begin
       transient_registration = WasteCarriersEngine::TransientRegistration.new(reg_identifier: reg_identifier)
       transient_registration.save!
+      counts[:success] += 1
       puts " ✓"
     rescue StandardError => e
       puts " ERROR"
-      error_count += 1
+      counts[:error] += 1
 
       log.info "\n----------"
       log.info "#{reg_identifier} - attempt to create transient_registration failed"
@@ -31,7 +72,5 @@ task create_transient_registrations: :environment do
     end
   end
 
-  puts "\nAttempted creation of #{registrations.count} transient_registrations complete"
-  puts "Errors: #{error_count}"
-  puts "Details saved to #{log_path}"
+  counts
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-145

When running this task against actual production data we found that it keeps erroring, but at different points. The error is always

```
rake aborted!
Mongo::Error::OperationFailure: cursor id 31540126646 not found (43)
/vagrant/waste-carriers-front-office/lib/tasks/create_transient_registrations.rake:16:in `block in <top (required)>'
/home/vagrant/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/home/vagrant/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => create_transient_registrations
(See full trace by running task with --trace)
```

Initial Googling seemed to indicate this was caused by a default timeout MongoDb has on cursors of 10  minutes (simply iterating through it does not seem to count as activity). So we trialled changing the query to include `no_cursor_timeout` and this allowed many more to complete, but we still eventually errored.

Next we incresed the number of CPU's being used in the VM this task is running in, and again got further before finally erroring.

So in the end we re-wrote the task to use paging to iterate through those registrations which are renewable and attempt to convert them. That combined with `no_cursor_timeout` and more CPU's meant we finally completed a run where we test converted all 122934 eligible registrations.
