### PR TITLE
Invalidate user session cookies after logout

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Users
+  class SessionsController < Devise::SessionsController
+    def destroy
+      current_user.invalidate_all_sessions!
+      super
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,20 @@ class User
   field :unlock_token,    type: String # Only if unlock strategy is :email or :both
   field :locked_at,       type: Time
 
+  # Devise security improvements, used to invalidate old sessions on logout
+  # Taken from https://makandracards.com/makandra/53562-devise-invalidating-all-sessions-for-a-user
+  field :session_token, type: String
+
+  def authenticatable_salt
+    "#{super}#{session_token}"
+  end
+
+  def invalidate_all_sessions!
+    self.session_token = SecureRandom.hex
+  end
+
+  # Validations
+
   validates :password, presence: true, length: { in: 8..128 }
   validate :password_must_have_lowercase_uppercase_and_numeric
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-446

After logging out, it's possible to repeat requests made while logged-in by reusing the cookie. This is a known issue with Devise, or more specifically with storing the session in the cookie.

Fortunately, we can fix this by adding a session_token field and using this to extend the salt. Then when a user logs out, we modify the session_token in the DB and the cookie can no longer be reused.