### PR TITLE
Stop users accessing pages with back button after signout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :back_button_cache_buster
+
   helper WasteCarriersEngine::ApplicationHelper
 
   # Within our production 'like' environments access to the app can only be
@@ -27,5 +29,12 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(*)
     new_user_session_path
+  end
+
+  # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
+  def back_button_cache_buster
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-446

We used this back_button_cache_buster method in the engine to prevent users from accessing forms with now-outdated information using the back button. However, it can also be used to stop people accessing restricted pages after signout by using the back button to access cached pages. So for security reasons, we're implementing it at the ApplicationController level.