### PR TITLE
Modify CSP to allow removal of PII in GTM

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -32,11 +32,12 @@ SecureHeaders::Configuration.default do |config|
   #
   # We have to use single quotes here, even though it's against style - double doesn't work
   config.csp = {
+    connect_src: %w('self' www.google-analytics.com),
     default_src: %w('self'),
     font_src: %w('self' data:),
     img_src: %w('self' www.google-analytics.com),
     object_src: %w('self'),
-    script_src: %w('self' 'unsafe-inline' www.googletagmanager.com www.google-analytics.com),
+    script_src: %w('self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com),
     style_src: %w('self'),
     report_uri: %w(https://environmentagency.report-uri.io/r/default/csp/enforce)
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-129

Update our Content Security Policy to allow custom JavaScript variables set up in Google Tag Manager. These variables remove personal identifiable information from URL paths before they are sent to Google Analytics.

We've also enabled beacons as a way of sending a hit to GA, so we need to add a `connect_src` key to our CSP. For more information about this, see: https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms

Note that if we want to use GTM's preview functionality, tagmanager.google.com also needs to be allowed in `script_src` - however I've left this out for now as we should be able to do this testing locally by modifying the CSP as needed, and it won't be needed in production.