### PR TITLE
Fix web console error in development log

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,4 +50,16 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  # The rails web console allows you to execute arbitrary code on the server. By
+  # default, only requests coming from IPv4 and IPv6 localhosts are allowed.
+  # When running in a vagrant box it'll use a different IP e.g. 10.0.2.2 so
+  # to stop getting `Cannot render console from 10.0.2.2!` in the logs you need
+  # to add its IP to this white list. The SSH_CLIENT holds this value but it
+  # contains some other stuff as well e.g. 10.0.2.2 59811 22. Hence we use fetch
+  # so we can assign the default (for none vagrant boxes) else grab the env var
+  # but just the first part of it.
+  # https://github.com/rails/web-console#configuration
+  # https://stackoverflow.com/a/29417509
+  config.web_console.whitelisted_ips = ENV.fetch("SSH_CLIENT", "127.0.0.1").split(" ").first
 end


### PR DESCRIPTION
Noticed when working on something else that all messages to the log when running it within our vagrant box included a line that started `Cannot render console from 10.0.2.2!` Some googling later and found this reason.

The rails web console allows you to execute arbitrary code on the server. By default, only requests coming from IPv4 and IPv6 localhosts are allowed. When running in a vagrant box it'll use a different IP e.g. 10.0.2.2 so to stop getting `Cannot render console from 10.0.2.2!` in the logs you need to add its IP to a white list in the rails config. The env var `SSH_CLIENT` holds this value but it contains some other stuff as well. When I looked on my machine is held `10.0.2.2 59811 22`.

Hence this change adds the current IP of the vagrant box to the web console's white listed IP's, else it it does what would have happened by default anyway.