### PR TITLE
Fix err msg WCR Engine::VERSION already defined

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 9de9bd7703d79746133c59da718e86aa82074a7d
+  revision: bc72860f7ace0b7ff75970b03d8ebe7a8cc2191b
   branch: master
   specs:
     waste_carriers_engine (0.0.1)

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -1,1 +1,0 @@
-WasteCarriersEngine::VERSION = Gem.loaded_specs["waste_carriers_engine"].version


### PR DESCRIPTION
When running unit tests or rake taks in the back office the first thing that appears is a warning message.

```bash
/vagrant/waste-carriers-front-office/config/initializers/waste_carriers_engine.rb:1: warning: already initialized constant WasteCarriersEngine::VERSION
/vagrant/waste-carriers-renewals/lib/waste_carriers_engine/version.rb:2: warning: previous definition of VERSION was here
```

After looking at the project, and comparing it to others where we have used a shared engine, spotted that we defined an initializer for the Waste carriers engine. In the initializer we then specify the version number for the engine.

This is not something we do in other projects so removed the initializer and this solved the warning message.