### PR TITLE
changing email account to less generic name

### DIFF
--- a/db/seeds/CBDU212.json
+++ b/db/seeds/CBDU212.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@mailinator.com",
+  "contactEmail": "wcr-user@mailinator.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@mailinator.com",
+  "accountEmail": "wcr-user@mailinator.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU212",

--- a/db/seeds/CBDU219.json
+++ b/db/seeds/CBDU219.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@mailinator.com",
+  "contactEmail": "wcr-user@mailinator.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@mailinator.com",
+  "accountEmail": "wcr-user@mailinator.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU219",

--- a/db/seeds/CBDU225.json
+++ b/db/seeds/CBDU225.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "user@mailinator.com",
+  "contactEmail": "wcr-user@mailinator.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "user@mailinator.com",
+  "accountEmail": "wcr-user@mailinator.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU225",

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -4,7 +4,7 @@
       "email": "user@example.com"
     },
     {
-      "email": "user@mailinator.com"
+      "email": "wcr-user@mailinator.com"
     },
     {
       "email": "another-user@example.com"


### PR DESCRIPTION
Sorry realised that user@mailinator.com was already utilised quite a lot so decided to change to a more specific waste carrier user account. I plan to clean up the emails after use but it didn't feel right sending the emails there.