### PR TITLE
Set up registration dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem "govuk_template", "~> 0.23"
 # Use High Voltage for static pages
 gem "high_voltage", "~> 3.0"
 
+# Use Kaminari for pagination
+gem "kaminari", "~> 1.1"
+gem "kaminari-mongoid", "~> 1.0"
+
 gem "secure_headers", "~> 5.0"
 
 # Use the waste carriers engine for the user journey

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,21 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
+    kaminari-mongoid (1.0.1)
+      kaminari-core (~> 1.0)
+      mongoid
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -340,6 +355,8 @@ DEPENDENCIES
   high_voltage (~> 3.0)
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari (~> 1.1)
+  kaminari-mongoid (~> 1.0)
   mongoid (~> 5.2.0)
   passenger (~> 5.0, >= 5.0.30)
   rails (= 4.2.11)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@
 @import 'partials/addresses';
 @import 'partials/dates';
 @import 'partials/footer';
+@import 'partials/pagination';
 @import 'partials/people';
 
 main {

--- a/app/assets/stylesheets/partials/_pagination.scss
+++ b/app/assets/stylesheets/partials/_pagination.scss
@@ -1,0 +1,65 @@
+// Cribbed from https://home-office-digital-patterns.herokuapp.com/components/pagination
+.pagination .pagination_list-items {
+
+  li {
+    display: inline-block;
+    a {
+      // @extend .bold-small;
+      color: $govuk-blue;
+      display: inline-block;
+      padding: 15px 5px 10px 5px;
+      margin-right: 15px;
+      text-decoration: none;
+
+      &:focus {
+        outline: 0;
+      }
+    }
+    &.active a,
+    &.active a:hover {
+      color: $govuk-blue;
+      -webkit-box-shadow: inset 0px -5px 0px 0px $govuk-blue;
+      -moz-box-shadow: inset 0px -5px 0px 0px $govuk-blue;
+      box-shadow: inset 0px -5px 0px 0px $govuk-blue;
+    }
+  }
+}
+
+.pagination {
+  padding: 0;
+}
+.pagination__item {
+  display: inline-block;
+  list-style: none;
+}
+.pagination__link {
+  display: block;
+  padding: 5px 10px;
+  text-decoration: none;
+
+  &:hover, &:focus {
+    background: $highlight-colour;
+    outline: 3px solid $focus-colour;
+  }
+
+  &.current {
+    color: $text-colour;
+    font-weight: 700;
+    border: none;
+    pointer-events: none;
+    cursor: default;
+
+    &:hover, &:focus {
+      color: $text-colour;
+      background: none;
+    }
+  }
+}
+
+.pagination__summary {
+  padding: 15px 0;
+
+  @media (min-width: 642px) {
+    float: right;
+  }
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -5,5 +5,6 @@ class DashboardsController < ApplicationController
 
   def index
     @registrations = WasteCarriersEngine::Registration.where(account_email: current_user.email)
+                                                      .page(params[:page])
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,6 +4,6 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    redirect_to(Rails.configuration.wcrs_frontend_url)
+    @registrations = WasteCarriersEngine::Registration.where(account_email: current_user.email)
   end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -19,7 +19,8 @@ module DashboardsHelper
     "#"
   end
 
-  def url_to_delete(_registration)
-    "#"
+  def url_to_delete(registration)
+    id = registration["_id"]
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/confirm_delete"
   end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module DashboardsHelper
+  def url_to_change_password
+    "#{Rails.configuration.wcrs_frontend_url}/users/edit"
+  end
+
   def display_view_certificate_link_for?(registration)
     registration.metaData.ACTIVE?
   end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module DashboardsHelper
-  def url_to_view_certificate_for(_registration)
-    "#"
+  def url_to_view_certificate_for(registration)
+    id = registration["_id"]
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/view"
   end
 
   def url_to_edit(_registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -5,8 +5,8 @@ module DashboardsHelper
     registration.metaData.ACTIVE?
   end
 
-  def display_edit_link_for?(_registration)
-    true
+  def display_edit_link_for?(registration)
+    registration.metaData.ACTIVE? || registration.metaData.PENDING?
   end
 
   def display_renew_link_for?(_registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -5,6 +5,10 @@ module DashboardsHelper
     "#{Rails.configuration.wcrs_frontend_url}/users/edit"
   end
 
+  def url_for_new_registration
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/find"
+  end
+
   def display_view_certificate_link_for?(registration)
     registration.metaData.ACTIVE?
   end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 module DashboardsHelper
+  def display_view_certificate_link_for?(_registration)
+    true
+  end
+
+  def display_edit_link_for?(_registration)
+    true
+  end
+
+  def display_renew_link_for?(_registration)
+    true
+  end
+
+  def display_order_cards_link_for?(_registration)
+    true
+  end
+
+  def display_delete_link_for?(_registration)
+    true
+  end
+
   def url_to_view_certificate_for(registration)
     "#{base_frontend_registration_url(registration)}/view"
   end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -13,8 +13,10 @@ module DashboardsHelper
     true
   end
 
-  def display_order_cards_link_for?(_registration)
-    true
+  def display_order_cards_link_for?(registration)
+    return false unless registration.tier == "UPPER"
+
+    registration.metaData.ACTIVE? || registration.metaData.PENDING?
   end
 
   def display_delete_link_for?(_registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -9,8 +9,8 @@ module DashboardsHelper
     "#"
   end
 
-  def url_to_renew(_registration)
-    "#"
+  def url_to_renew(registration)
+    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(registration.reg_identifier)
   end
 
   def url_to_order_cards_for(_registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module DashboardsHelper
-  def display_view_certificate_link_for?(_registration)
-    true
+  def display_view_certificate_link_for?(registration)
+    registration.metaData.ACTIVE?
   end
 
   def display_edit_link_for?(_registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -15,8 +15,9 @@ module DashboardsHelper
     WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(registration.reg_identifier)
   end
 
-  def url_to_order_cards_for(_registration)
-    "#"
+  def url_to_order_cards_for(registration)
+    id = registration["_id"]
+    "#{Rails.configuration.wcrs_frontend_url}/your-registration/#{id}/order/order-copy_cards"
   end
 
   def url_to_delete(registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -6,8 +6,9 @@ module DashboardsHelper
     "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/view"
   end
 
-  def url_to_edit(_registration)
-    "#"
+  def url_to_edit(registration)
+    id = registration["_id"]
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/edit"
   end
 
   def url_to_renew(registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DashboardsHelper
+  def url_to_view_certificate_for(_registration)
+    "#"
+  end
+
+  def url_to_edit(_registration)
+    "#"
+  end
+
+  def url_to_renew(_registration)
+    "#"
+  end
+
+  def url_to_order_cards_for(_registration)
+    "#"
+  end
+
+  def url_to_delete(_registration)
+    "#"
+  end
+end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -19,8 +19,8 @@ module DashboardsHelper
     registration.metaData.ACTIVE? || registration.metaData.PENDING?
   end
 
-  def display_delete_link_for?(_registration)
-    true
+  def display_delete_link_for?(registration)
+    registration.metaData.ACTIVE?
   end
 
   def url_to_view_certificate_for(registration)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -2,13 +2,11 @@
 
 module DashboardsHelper
   def url_to_view_certificate_for(registration)
-    id = registration["_id"]
-    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/view"
+    "#{base_frontend_registration_url(registration)}/view"
   end
 
   def url_to_edit(registration)
-    id = registration["_id"]
-    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/edit"
+    "#{base_frontend_registration_url(registration)}/edit"
   end
 
   def url_to_renew(registration)
@@ -21,7 +19,13 @@ module DashboardsHelper
   end
 
   def url_to_delete(registration)
+    "#{base_frontend_registration_url(registration)}/confirm_delete"
+  end
+
+  private
+
+  def base_frontend_registration_url(registration)
     id = registration["_id"]
-    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/confirm_delete"
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}"
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -3,6 +3,7 @@
     <div id="user-status">
       <p>
         <%= t(".user_info.signed_in_user", email: current_user.email) %>
+        <%= link_to t(".user_info.change_password_link"), url_to_change_password %>
         <%= link_to t(".user_info.sign_out_link"), destroy_user_session_path %>
       </p>
     </div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -52,7 +52,11 @@
                 <%= registration.company_name %>
               </td>
               <td>
-                <%= registration.registered_address.postcode %>
+                <% if registration.registered_address.present? %>
+                  <%= registration.registered_address.postcode %>
+                <% else %>
+                  <%= t(".results.registered_address_postcode.not_applicable") %>
+                <% end %>
               </td>
               <td>
                 <%= registration.reg_identifier %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,0 +1,77 @@
+<div class="grid-row">
+  <div class="column-full">
+    <div id="user-status">
+      <p>
+        <%= t(".user_info.signed_in_user", email: current_user.email) %>
+        <%= link_to t(".user_info.sign_out_link"), destroy_user_session_path %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <p><%= t(".summary.paragraph_1") %></p>
+    <p><%= t(".summary.paragraph_2") %></p>
+    <ul class="list list-bullet">
+      <% t(".summary.list").each do |list_item| %>
+        <li><%= list_item %></li>
+      <% end %>
+    </ul>
+    <p><%= t(".summary.paragraph_3") %></p>
+    <p><%= t(".summary.paragraph_4", count: @registrations.count) %></p>
+  </div>
+</div>
+
+<% if @registrations.present? %>
+  <div class="grid-row">
+    <div class="column-full">
+      <table>
+        <thead>
+          <tr>
+            <th><%= t(".results.th.company_name") %></th>
+            <th><%= t(".results.th.registered_address_postcode") %></th>
+            <th><%= t(".results.th.reg_identifier") %></th>
+            <th><%= t(".results.th.status") %></th>
+            <th><%= t(".results.th.expires_on") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @registrations.each do |registration| %>
+            <tr>
+              <td>
+                <%= registration.company_name %>
+              </td>
+              <td>
+                <%= registration.registered_address.postcode %>
+              </td>
+              <td>
+                <%= registration.reg_identifier %>
+              </td>
+              <td>
+                <%= registration.metaData.status %>
+              </td>
+              <td>
+                <% if registration.expires_on.present? %>
+                  <%= registration.expires_on.to_date %>
+                <% else %>
+                  <% t(".results.expires_on.not_applicable") %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% else %>
+  <p><%= t(".results.no_results") %></p>
+<% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -42,6 +42,7 @@
             <th><%= t(".results.th.reg_identifier") %></th>
             <th><%= t(".results.th.status") %></th>
             <th><%= t(".results.th.expires_on") %></th>
+            <th><%= t(".results.th.actions") %></th>
           </tr>
         </thead>
         <tbody>
@@ -63,8 +64,32 @@
                 <% if registration.expires_on.present? %>
                   <%= registration.expires_on.to_date %>
                 <% else %>
-                  <% t(".results.expires_on.not_applicable") %>
+                  <%= t(".results.expires_on.not_applicable") %>
                 <% end %>
+              </td>
+              <td>
+                <ul>
+                  <li>
+                    <%= link_to t(".results.actions.view_certificate"),
+                                url_to_view_certificate_for(registration) %>
+                  </li>
+                  <li>
+                    <%= link_to t(".results.actions.edit"),
+                                url_to_edit(registration) %>
+                  </li>
+                  <li>
+                    <%= link_to t(".results.actions.renew"),
+                                url_to_renew(registration) %>
+                  </li>
+                  <li>
+                    <%= link_to t(".results.actions.order_cards"),
+                                url_to_order_cards_for(registration) %>
+                  </li>
+                  <li>
+                    <%= link_to t(".results.actions.delete"),
+                                url_to_delete(registration) %>
+                  </li>
+                </ul>
               </td>
             </tr>
           <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -72,6 +72,17 @@
       </table>
     </div>
   </div>
+
+  <div class="grid-row">
+    <div class="column-full">
+      <nav role="navigation" class="pagination" aria-label="Pagination">
+        <div class="pagination__summary">
+          <%= page_entries_info @registrations, entry_name: "item" %>
+        </div>
+        <%= paginate @registrations %>
+      </nav>
+    </div>
+  </div>
 <% else %>
   <p><%= t(".results.no_results") %></p>
 <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -126,3 +126,11 @@
 <% else %>
   <p><%= t(".results.no_results") %></p>
 <% end %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to t(".new_registration_button"),
+                url_for_new_registration,
+                class: "button" %>
+  </div>
+</div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -73,26 +73,36 @@
               </td>
               <td>
                 <ul>
-                  <li>
-                    <%= link_to t(".results.actions.view_certificate"),
-                                url_to_view_certificate_for(registration) %>
-                  </li>
-                  <li>
-                    <%= link_to t(".results.actions.edit"),
-                                url_to_edit(registration) %>
-                  </li>
-                  <li>
-                    <%= link_to t(".results.actions.renew"),
-                                url_to_renew(registration) %>
-                  </li>
-                  <li>
-                    <%= link_to t(".results.actions.order_cards"),
-                                url_to_order_cards_for(registration) %>
-                  </li>
-                  <li>
-                    <%= link_to t(".results.actions.delete"),
-                                url_to_delete(registration) %>
-                  </li>
+                  <% if display_view_certificate_link_for?(registration) %>
+                    <li>
+                      <%= link_to t(".results.actions.view_certificate"),
+                                  url_to_view_certificate_for(registration) %>
+                    </li>
+                  <% end %>
+                  <% if display_edit_link_for?(registration) %>
+                    <li>
+                      <%= link_to t(".results.actions.edit"),
+                                  url_to_edit(registration) %>
+                    </li>
+                  <% end %>
+                  <% if display_renew_link_for?(registration) %>
+                    <li>
+                      <%= link_to t(".results.actions.renew"),
+                                  url_to_renew(registration) %>
+                    </li>
+                  <% end %>
+                  <% if display_order_cards_link_for?(registration) %>
+                    <li>
+                      <%= link_to t(".results.actions.order_cards"),
+                                  url_to_order_cards_for(registration) %>
+                    </li>
+                  <% end %>
+                  <% if display_delete_link_for?(registration) %>
+                    <li>
+                      <%= link_to t(".results.actions.delete"),
+                                  url_to_delete(registration) %>
+                    </li>
+                  <% end %>
                 </ul>
               </td>
             </tr>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,9 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.first?, raw(t("views.pagination.first")),
+                                          url,
+                                          {
+                                            remote: remote,
+                                            class: "pagination__link",
+                                            "aria-label": "First page"
+                                          } %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class="disabled">
+  <%= content_tag :a, raw(t("views.pagination.truncate")) %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,9 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.last?, raw(t("views.pagination.last")),
+                                         url,
+                                         {
+                                           remote: remote,
+                                           class: "pagination__link",
+                                           "aria-label": "Last page"
+                                          } %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,10 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.last?, raw(t("views.pagination.next")),
+                                         url,
+                                         {
+                                           rel: "next",
+                                           remote: remote,
+                                           class: "pagination__link",
+                                           "aria-label": "Next page"
+                                          } %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,24 @@
+<% if page.current? %>
+  <li class="active pagination__item">
+    <%= content_tag :a,
+                    page,
+                    {
+                      remote: remote,
+                      rel: (page.next? ? "next" : (page.prev? ? "prev" : nil)),
+                      class: "pagination__link current",
+                      "aria-current": "true",
+                      "aria-label": "Page #{page}, current page"
+                    } %>
+  </li>
+<% else %>
+  <li class="pagination__item">
+    <%= link_to page,
+                url,
+                {
+                  remote: remote,
+                  rel: (page.next? ? "next" : (page.prev? ? "prev" : nil)),
+                  class: "pagination__link",
+                  "aria-label": "Page #{page}"
+                } %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,15 @@
+<%= paginator.render do %>
+  <ul class="pagination_list-items">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| %>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </ul>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,10 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.first?, raw(t("views.pagination.previous")),
+                                          url,
+                                          {
+                                            rel: "prev",
+                                            remote: remote,
+                                            class: "pagination__link",
+                                            "aria-label": "Previous page"
+                                           } %>
+</li>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  config.window = 2
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -4,6 +4,7 @@ en:
       title: "Your waste carrier registrations"
       user_info:
         signed_in_user: "Signed in as %{email}."
+        change_password_link: "Change password"
         sign_out_link: "Sign out"
       heading: "Your waste carrier registrations"
       summary:

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -24,6 +24,13 @@ en:
           reg_identifier: "Registration"
           status: "Status"
           expires_on: "Expiry date"
+          actions: "Actions"
         expires_on:
           not_applicable: "N/A"
+        actions:
+          view_certificate: "View certificate"
+          edit: "Edit"
+          renew: "Renew"
+          order_cards: "Order copy cards"
+          delete: "Delete"
         no_results: "No results found."

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -25,6 +25,8 @@ en:
           status: "Status"
           expires_on: "Expiry date"
           actions: "Actions"
+        registered_address_postcode:
+          not_applicable: "N/A"
         expires_on:
           not_applicable: "N/A"
         actions:

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -1,0 +1,29 @@
+en:
+  dashboards:
+    index:
+      title: "Your waste carrier registrations"
+      user_info:
+        signed_in_user: "Signed in as %{email}."
+        sign_out_link: "Sign out"
+      heading: "Your waste carrier registrations"
+      summary:
+        paragraph_1: "These are the registrations linked to your account."
+        paragraph_2: "You can:"
+        list:
+          - "create new registrations for your business or organisation"
+          - "change the details of your existing registrations"
+          - "view your registration certificates"
+        paragraph_3: "If any of your details do change in the future you must update the registration within 28 days."
+        paragraph_4:
+          one: "You have 1 registration."
+          other: "You have %{count} registrations."
+      results:
+        th:
+          company_name: "Company name"
+          registered_address_postcode: "Postcode"
+          reg_identifier: "Registration"
+          status: "Status"
+          expires_on: "Expiry date"
+        expires_on:
+          not_applicable: "N/A"
+        no_results: "No results found."

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -37,3 +37,4 @@ en:
           order_cards: "Order copy cards"
           delete: "Delete"
         no_results: "No results found."
+      new_registration_button: "New registration"

--- a/config/locales/kaminari.en.yml
+++ b/config/locales/kaminari.en.yml
@@ -1,0 +1,10 @@
+en:
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "No results found"
+          one: "Displaying 1 result"
+          other: "Displaying all %{count} results"
+      more_pages:
+        display_entries: "Showing %{first} &ndash; %{last} of %{total} results"

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe DashboardsHelper, type: :helper do
     allow(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://www.example.com")
   end
 
+  describe "#url_to_change_password" do
+    it "returns the correct URL" do
+      password_url = "http://www.example.com/users/edit"
+      expect(helper.url_to_change_password).to eq(password_url)
+    end
+  end
+
   describe "#display_view_certificate_link_for?" do
     context "when the registration is active" do
       before { registration.metaData.status = "ACTIVE" }

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe DashboardsHelper, type: :helper do
     end
   end
 
+  describe "#url_for_new_registration" do
+    it "returns the correct URL" do
+      registration_url = "http://www.example.com/registrations/find"
+      expect(helper.url_for_new_registration).to eq(registration_url)
+    end
+  end
+
   describe "#display_view_certificate_link_for?" do
     context "when the registration is active" do
       before { registration.metaData.status = "ACTIVE" }

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -30,8 +30,28 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#display_edit_link_for?" do
-    it "returns the correct value" do
-      expect(helper.display_edit_link_for?(registration)).to eq(true)
+    context "when the registration is active" do
+      before { registration.metaData.status = "ACTIVE" }
+
+      it "returns true" do
+        expect(helper.display_edit_link_for?(registration)).to eq(true)
+      end
+    end
+
+    context "when the registration is pending" do
+      before { registration.metaData.status = "PENDING" }
+
+      it "returns true" do
+        expect(helper.display_edit_link_for?(registration)).to eq(true)
+      end
+    end
+
+    context "when the registration is not active or pending" do
+      before { registration.metaData.status = "REVOKED" }
+
+      it "returns false" do
+        expect(helper.display_edit_link_for?(registration)).to eq(false)
+      end
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -5,10 +5,16 @@ require "rails_helper"
 RSpec.describe DashboardsHelper, type: :helper do
   let(:registration) { create(:registration) }
   let(:reg_identifier) { registration.reg_identifier }
+  let(:id) { registration["_id"] }
+
+  before do
+    allow(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://www.example.com")
+  end
 
   describe "#url_to_view_certificate_for" do
-    it "returns a temp value" do
-      expect(helper.url_to_view_certificate_for(registration)).to eq("#")
+    it "returns the correct URL" do
+      certificate_url = "http://www.example.com/registrations/#{id}/view"
+      expect(helper.url_to_view_certificate_for(registration)).to eq(certificate_url)
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#url_to_delete" do
-    it "returns a temp value" do
-      expect(helper.url_to_delete(registration)).to eq("#")
+    it "returns the correct URL" do
+      delete_url = "http://www.example.com/registrations/#{id}/confirm_delete"
+      expect(helper.url_to_delete(registration)).to eq(delete_url)
     end
   end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -100,8 +100,20 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#display_delete_link_for?" do
-    it "returns the correct value" do
-      expect(helper.display_delete_link_for?(registration)).to eq(true)
+    context "when the registration is active" do
+      before { registration.metaData.status = "ACTIVE" }
+
+      it "returns true" do
+        expect(helper.display_delete_link_for?(registration)).to eq(true)
+      end
+    end
+
+    context "when the registration is not active" do
+      before { registration.metaData.status = "PENDING" }
+
+      it "returns false" do
+        expect(helper.display_delete_link_for?(registration)).to eq(false)
+      end
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.describe DashboardsHelper, type: :helper do
-  let(:registration) { build(:registration) }
+  let(:registration) { create(:registration) }
+  let(:reg_identifier) { registration.reg_identifier }
 
   describe "#url_to_view_certificate_for" do
     it "returns a temp value" do
@@ -18,8 +19,9 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#url_to_renew" do
-    it "returns a temp value" do
-      expect(helper.url_to_renew(registration)).to eq("#")
+    it "returns the correct URL" do
+      renew_url = "/fo/renew/#{reg_identifier}"
+      expect(helper.url_to_renew(registration)).to eq(renew_url)
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -11,6 +11,36 @@ RSpec.describe DashboardsHelper, type: :helper do
     allow(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://www.example.com")
   end
 
+  describe "#display_view_certificate_link_for?" do
+    it "returns the correct value" do
+      expect(helper.display_view_certificate_link_for?(registration)).to eq(true)
+    end
+  end
+
+  describe "#display_edit_link_for?" do
+    it "returns the correct value" do
+      expect(helper.display_edit_link_for?(registration)).to eq(true)
+    end
+  end
+
+  describe "#display_renew_link_for?" do
+    it "returns the correct value" do
+      expect(helper.display_renew_link_for?(registration)).to eq(true)
+    end
+  end
+
+  describe "#display_order_cards_link_for?" do
+    it "returns the correct value" do
+      expect(helper.display_order_cards_link_for?(registration)).to eq(true)
+    end
+  end
+
+  describe "#display_delete_link_for?" do
+    it "returns the correct value" do
+      expect(helper.display_delete_link_for?(registration)).to eq(true)
+    end
+  end
+
   describe "#url_to_view_certificate_for" do
     it "returns the correct URL" do
       certificate_url = "http://www.example.com/registrations/#{id}/view"

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DashboardsHelper, type: :helper do
+  let(:registration) { build(:registration) }
+
+  describe "#url_to_view_certificate_for" do
+    it "returns a temp value" do
+      expect(helper.url_to_view_certificate_for(registration)).to eq("#")
+    end
+  end
+
+  describe "#url_to_edit" do
+    it "returns a temp value" do
+      expect(helper.url_to_edit(registration)).to eq("#")
+    end
+  end
+
+  describe "#url_to_renew" do
+    it "returns a temp value" do
+      expect(helper.url_to_renew(registration)).to eq("#")
+    end
+  end
+
+  describe "#url_to_order_cards_for" do
+    it "returns a temp value" do
+      expect(helper.url_to_order_cards_for(registration)).to eq("#")
+    end
+  end
+
+  describe "#url_to_delete" do
+    it "returns a temp value" do
+      expect(helper.url_to_delete(registration)).to eq("#")
+    end
+  end
+end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -33,8 +33,9 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#url_to_order_cards_for" do
-    it "returns a temp value" do
-      expect(helper.url_to_order_cards_for(registration)).to eq("#")
+    it "returns the correct URL" do
+      cards_url = "http://www.example.com/your-registration/#{id}/order/order-copy_cards"
+      expect(helper.url_to_order_cards_for(registration)).to eq(cards_url)
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#url_to_edit" do
-    it "returns a temp value" do
-      expect(helper.url_to_edit(registration)).to eq("#")
+    it "returns the correct URL" do
+      edit_url = "http://www.example.com/registrations/#{id}/edit"
+      expect(helper.url_to_edit(registration)).to eq(edit_url)
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -12,8 +12,20 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#display_view_certificate_link_for?" do
-    it "returns the correct value" do
-      expect(helper.display_view_certificate_link_for?(registration)).to eq(true)
+    context "when the registration is active" do
+      before { registration.metaData.status = "ACTIVE" }
+
+      it "returns true" do
+        expect(helper.display_view_certificate_link_for?(registration)).to eq(true)
+      end
+    end
+
+    context "when the registration is not active" do
+      before { registration.metaData.status = "PENDING" }
+
+      it "returns false" do
+        expect(helper.display_view_certificate_link_for?(registration)).to eq(false)
+      end
     end
   end
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -62,8 +62,40 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#display_order_cards_link_for?" do
-    it "returns the correct value" do
-      expect(helper.display_order_cards_link_for?(registration)).to eq(true)
+    context "when the registration is upper tier" do
+      before { registration.tier = "UPPER" }
+
+      context "when the registration is active" do
+        before { registration.metaData.status = "ACTIVE" }
+
+        it "returns true" do
+          expect(helper.display_order_cards_link_for?(registration)).to eq(true)
+        end
+      end
+
+      context "when the registration is pending" do
+        before { registration.metaData.status = "PENDING" }
+
+        it "returns true" do
+          expect(helper.display_order_cards_link_for?(registration)).to eq(true)
+        end
+      end
+
+      context "when the registration is not active or pending" do
+        before { registration.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_order_cards_link_for?(registration)).to eq(false)
+        end
+      end
+    end
+
+    context "when the registration is lower tier" do
+      before { registration.tier = "LOWER" }
+
+      it "returns false" do
+        expect(helper.display_order_cards_link_for?(registration)).to eq(false)
+      end
     end
   end
 

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Dashboards", type: :request do
+RSpec.describe "Dashfoards", type: :request do
   describe "/fo" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
@@ -10,14 +10,35 @@ RSpec.describe "Dashboards", type: :request do
         sign_in(user)
       end
 
-      it "redirects to the frontend user dashboard" do
+      it "renders the index template" do
         get "/fo"
-        expect(response.body).to include(Rails.configuration.wcrs_frontend_url)
+        expect(response).to render_template(:index)
       end
 
-      it "returns a 302 response" do
+      it "returns a 200 response" do
         get "/fo"
-        expect(response).to have_http_status(302)
+        expect(response).to have_http_status(200)
+      end
+
+      it "lists registrations which belong to the user" do
+        reg_identifier = create(:registration, account_email: user.email).reg_identifier
+
+        get "/fo"
+        expect(response.body).to include(reg_identifier)
+      end
+
+      it "does not list registrations which don't belong to the user" do
+        reg_identifier = create(:registration, account_email: "foo@example.com").reg_identifier
+
+        get "/fo"
+        expect(response.body).to_not include(reg_identifier)
+      end
+
+      context "when the user has no registrations" do
+        it "says there are no results" do
+          get "/fo"
+          expect(response.body).to include("No results")
+        end
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-14

This feature comes out of our attempt to fix time-outs which occur when a user with a large number of registrations tries to view their dashboard. The frontend requests allll their registrations from the Java service. This takes a long time and means the request times out, so the user just gets an error.

We attempted to fix this by introducing pagination: DEFRA/waste-carriers-frontend#178 However, this didn't resolve the underlying issue of only getting registration data from the Java service instead of directly from the database, so the error still occurred.

Rather than re-engineer the frontend and the Java service to make this work, it seemed more expedient to just re-implement the dashboard in the front-office, this time loading data directly from the database, and including pagination to avoid timeouts.

---

WIP