### PR TITLE
Make dashboard links more accessible

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -87,40 +87,55 @@
             <% if display_view_certificate_link_for?(registration) %>
               <li>
                 <%= link_to view_certificate_url(registration) do %>
-                 <%= t(".results.actions.view_certificate") %>
-                 <span class="visually-hidden"><%= registration.company_name %></span>
+                 <%= t(".results.actions.view_certificate.link_text") %>
+                 <span class="visually-hidden">
+                   <%= t(".results.actions.view_certificate.visually_hidden_text",
+                         name: registration.company_name) %>
+                 </span>
                 <% end %>
               </li>
             <% end %>
             <% if display_edit_link_for?(registration) %>
               <li>
                 <%= link_to edit_url(registration) do %>
-                  <%= t(".results.actions.edit") %>
-                  <span class="visually-hidden"><%= registration.company_name %></span>
+                  <%= t(".results.actions.edit.link_text") %>
+                  <span class="visually-hidden">
+                    <%= t(".results.actions.edit.visually_hidden_text",
+                          name: registration.company_name) %>
+                  </span>
                 <% end %>
               </li>
             <% end %>
             <% if display_renew_link_for?(registration) %>
               <li>
                 <%= link_to renew_url(registration) do %>
-                  <%= t(".results.actions.renew") %>
-                  <span class="visually-hidden"><%= registration.company_name %></span>
+                  <%= t(".results.actions.renew.link_text") %>
+                  <span class="visually-hidden">
+                    <%= t(".results.actions.renew.visually_hidden_text",
+                          name: registration.company_name) %>
+                  </span>
                 <% end %>
               </li>
             <% end %>
             <% if display_order_cards_link_for?(registration) %>
               <li>
                 <%= link_to order_cards_url(registration) do %>
-                  <%= t(".results.actions.order_cards") %>
-                  <span class="visually-hidden"><%= registration.company_name %></span>
+                  <%= t(".results.actions.order_cards.link_text") %>
+                  <span class="visually-hidden">
+                    <%= t(".results.actions.order_cards.visually_hidden_text",
+                          name: registration.company_name) %>
+                  </span>
                 <% end %>
               </li>
             <% end %>
             <% if display_delete_link_for?(registration) %>
               <li>
                 <%= link_to delete_url(registration) do %>
-                  <%= t(".results.actions.delete") %>
-                  <span class="visually-hidden"><%= registration.company_name %></span>
+                  <%= t(".results.actions.delete.link_text") %>
+                  <span class="visually-hidden">
+                    <%= t(".results.actions.delete.visually_hidden_text",
+                          name: registration.company_name) %>
+                  </span>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -86,32 +86,37 @@
           <ul>
             <% if display_view_certificate_link_for?(registration) %>
               <li>
-                <%= link_to t(".results.actions.view_certificate"),
-                            view_certificate_url(registration) %>
+                <%= link_to view_certificate_url(registration) do %>
+                 <%= t(".results.actions.view_certificate") %>
+                <% end %>
               </li>
             <% end %>
             <% if display_edit_link_for?(registration) %>
               <li>
-                <%= link_to t(".results.actions.edit"),
-                            edit_url(registration) %>
+                <%= link_to edit_url(registration) do %>
+                  <%= t(".results.actions.edit") %>
+                <% end %>
               </li>
             <% end %>
             <% if display_renew_link_for?(registration) %>
               <li>
-                <%= link_to t(".results.actions.renew"),
-                            renew_url(registration) %>
+                <%= link_to renew_url(registration) do %>
+                  <%= t(".results.actions.renew") %>
+                <% end %>
               </li>
             <% end %>
             <% if display_order_cards_link_for?(registration) %>
               <li>
-                <%= link_to t(".results.actions.order_cards"),
-                            order_cards_url(registration) %>
+                <%= link_to order_cards_url(registration) do %>
+                  <%= t(".results.actions.order_cards") %>
+                <% end %>
               </li>
             <% end %>
             <% if display_delete_link_for?(registration) %>
               <li>
-                <%= link_to t(".results.actions.delete"),
-                            delete_url(registration) %>
+                <%= link_to delete_url(registration) do %>
+                  <%= t(".results.actions.delete") %>
+                <% end %>
               </li>
             <% end %>
           </ul>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -88,6 +88,7 @@
               <li>
                 <%= link_to view_certificate_url(registration) do %>
                  <%= t(".results.actions.view_certificate") %>
+                 <span class="visually-hidden"><%= registration.company_name %></span>
                 <% end %>
               </li>
             <% end %>
@@ -95,6 +96,7 @@
               <li>
                 <%= link_to edit_url(registration) do %>
                   <%= t(".results.actions.edit") %>
+                  <span class="visually-hidden"><%= registration.company_name %></span>
                 <% end %>
               </li>
             <% end %>
@@ -102,6 +104,7 @@
               <li>
                 <%= link_to renew_url(registration) do %>
                   <%= t(".results.actions.renew") %>
+                  <span class="visually-hidden"><%= registration.company_name %></span>
                 <% end %>
               </li>
             <% end %>
@@ -109,6 +112,7 @@
               <li>
                 <%= link_to order_cards_url(registration) do %>
                   <%= t(".results.actions.order_cards") %>
+                  <span class="visually-hidden"><%= registration.company_name %></span>
                 <% end %>
               </li>
             <% end %>
@@ -116,6 +120,7 @@
               <li>
                 <%= link_to delete_url(registration) do %>
                   <%= t(".results.actions.delete") %>
+                  <span class="visually-hidden"><%= registration.company_name %></span>
                 <% end %>
               </li>
             <% end %>

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -28,11 +28,21 @@ en:
           expires_on: "Expiry date"
           actions: "Actions"
         actions:
-          view_certificate: "View certificate"
-          edit: "Edit"
-          renew: "Renew"
-          order_cards: "Order copy cards"
-          delete: "Delete"
+          view_certificate:
+            link_text: "View certificate"
+            visually_hidden_text: "for registration for %{name}"
+          edit:
+            link_text: "Edit"
+            visually_hidden_text: "registration for %{name}"
+          renew:
+            link_text: "Renew"
+            visually_hidden_text: "registration for %{name}"
+          order_cards:
+            link_text: "Order copy cards"
+            visually_hidden_text: "for registration for %{name}"
+          delete:
+            link_text: "Delete"
+            visually_hidden_text: "registration for %{name}"
           no_actions: "None"
         no_results: "No results found."
       new_registration_button: "New registration"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-14

If a user has many registrations, the link text for registration actions will be duplicated for each registration. Having multiple links with the same text (eg 'view certificate') on a page isn't good for screenreaders, so we need to make this links unique.
