### PR TITLE
Don't list inactive registrations on dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,7 +4,8 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @registrations = WasteCarriersEngine::Registration.where(account_email: current_user.email)
+    @registrations = WasteCarriersEngine::Registration.where(account_email: current_user.email,
+                                                             :'metaData.status'.ne => "INACTIVE")
                                                       .order_by("metaData.dateRegistered": :asc)
                                                       .page(params[:page])
   end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe "Dashfoards", type: :request do
         expect(response.body).to_not include(reg_identifier)
       end
 
+      it "does not list registrations which are inactive" do
+        registration = create(:registration)
+        registration.metaData.status = "INACTIVE"
+        reg_identifier = registration.reg_identifier
+
+        get "/fo"
+        expect(response.body).to_not include(reg_identifier)
+      end
+
       context "when the user has no registrations" do
         it "says there are no results" do
           get "/fo"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-14

This change is to match the behaviour of the old dashboard in waste-carriers-frontend. Once a user deregisters a registration, they can no longer see it, although it remains in the database for now.