### PR TITLE
Unlock Rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "jquery-rails"
 # mongoid supports MongoDb 3.6
 gem "mongoid", "~> 5.2.0"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails"
-gem "rails", "4.2.11"
+gem "rails", "~> 4.2.11"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 5.0"
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ DEPENDENCIES
   kaminari-mongoid (~> 1.0)
   mongoid (~> 5.2.0)
   passenger (~> 5.0, >= 5.0.30)
-  rails (= 4.2.11)
+  rails (~> 4.2.11)
   rspec-rails (~> 3.6)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
Previously our Gemfiles locked Rails to a specific version (4.2.11). This meant that Dependabot would not prompt us with upgrades. As there is now a critical security patch we'd like to apply, we've decided it's better to accept 4.2.11 and above (within the 4.2 range). This should allow Dependabot to submit PRs for patch-level changes to Rails.