### PR TITLE
Switch to new engine repo name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "secure_headers", "~> 5.0"
 
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
-    git: "https://github.com/DEFRA/waste-carriers-renewals",
+    git: "https://github.com/DEFRA/waste-carriers-engine",
     branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/DEFRA/waste-carriers-renewals
+  remote: https://github.com/DEFRA/waste-carriers-engine
   revision: 2562c1637a4988576742b8f12d26453b68bb0433
   branch: master
   specs:
@@ -375,4 +375,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The 'Register or renew as a waste carrier' service allows businesses, who deal w
 
 The service also allows authorised agency users and NCCC staff to create and manage registrations on other users' behalf, e.g. to support 'Assisted Digital' registrations. The service provides an internal user account management facility which allows authorised administrators to create and manage other agency user accounts.
 
-This project is the front office application which members of the public use to renew a registration. It uses the [waste-carriers-renewals engine](https://github.com/DEFRA/waste-carriers-renewals).
+This project is the front office application which members of the public to renew a registration. It uses the [waste carriers engine](https://github.com/DEFRA/waste-carriers-engine).
 
 ## Prequisites
 
@@ -33,12 +33,12 @@ bundle install
 
 A [Vagrant](https://www.vagrantup.com/) instance has been created allowing easy setup of the waste carriers service. It includes installing all applications, databases and dependencies. This is located within GitLab (speak to the Ruby team).
 
-Download the Vagrant project and create the VM using the instructions in its README. It includes installing and running a version of the renewals app.
+Download the Vagrant project and create the VM using the instructions in its README. It includes installing and running a version of the waste-carriers-front-office app.
 
-However, if you intend to work with the renewals app locally (as opposed to on the Vagrant instance) and just use the box for dependencies, you'll need to:
+However, if you intend to work with the app locally (as opposed to on the Vagrant instance) and just use the box for dependencies, you'll need to:
 
 - Log in into the Vagrant instance
-- Using `ps ax`, identify the pid of the running renewals app
+- Using `ps ax`, identify the pid of the running waste-carriers-front-office app
 - Kill it using `kill [pid id]`
 - Exit the vagrant instance
 


### PR DESCRIPTION
We have renamed the engine repo from waste-carriers-renewals to waste-carriers-engine. This commit updates the        Gemfile.

It also updates the content of the README to use the correct name of the application.