### PR TITLE
Hardcode pages links

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,8 +3,8 @@
     <%= t(".support_text") %>
   </p>
   <ul>
-    <li class="inline"><%= link_to "Privacy", "/fo#{page_path("privacy")}",  target: "_blank" %></li>
-    <li class="inline"><%= link_to "Cookies", "/fo#{page_path("cookies")}",  target: "_blank" %></li>
-    <li class="inline"><%= link_to "Accessibility", "/fo#{page_path("accessibility")}",  target: "_blank" %></li>
+    <li class="inline"><%= link_to "Privacy", "/fo/pages/privacy",  target: "_blank" %></li>
+    <li class="inline"><%= link_to "Cookies", "/fo/pages/cookies",  target: "_blank" %></li>
+    <li class="inline"><%= link_to "Accessibility", "/fo/pages/accessibility",  target: "_blank" %></li>
   </ul>
 </div>


### PR DESCRIPTION
There is some issue around the fact that bot Devise and HighVoltage are engines, and that we re-define the HighVoltage routes in a third engine, which is the WCR engine. This generate a situation where we are able to either have the route helper be visible with the right engine `:mount` namespace in one place or in the other. 
This have to deal with the login page on front-office, which is managed by Devise, and is using the shared partial object of this PR. 
All other pages using the partial are constructing it correctly, but the Devise page is not. 
Since we have no idea of the cause and we have spent on it a reasonable amount of time already, this is the quick fix we want to merge in order to fix the bug in production. 