### PR TITLE
Use RenewingRegistration instead of TransientRegistration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "secure_headers", "~> 5.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "756-renewing-registration-in-controllers"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "secure_headers", "~> 5.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "756-renewing-registration-in-controllers"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: b6ebb569852e9b67f51cee6346fd702d9fb684a4
-  branch: 756-renewing-registration-in-controllers
+  revision: 3d0f18a245005dd113edfd4c134591ac5911d0bd
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 54e95e4c4011eb174e86d293594ad6d1aedfb12f
-  branch: master
+  revision: b6ebb569852e9b67f51cee6346fd702d9fb684a4
+  branch: 756-renewing-registration-in-controllers
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -22,8 +22,8 @@ module DashboardsHelper
 
     reg_id = registration.reg_identifier
     # Use existing transient_registration or create a temporary new one
-    transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_id).first ||
-                             WasteCarriersEngine::TransientRegistration.new(reg_identifier: reg_id)
+    transient_registration = WasteCarriersEngine::RenewingRegistration.where(reg_identifier: reg_id).first ||
+                             WasteCarriersEngine::RenewingRegistration.new(reg_identifier: reg_id)
 
     transient_registration.can_be_renewed?
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,6 +5,6 @@ class Ability
 
   def initialize(user)
     can :read, WasteCarriersEngine::Registration, account_email: user.email
-    can :manage, WasteCarriersEngine::TransientRegistration, account_email: user.email
+    can :manage, WasteCarriersEngine::RenewingRegistration, account_email: user.email
   end
 end

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,0 +1,3 @@
+HighVoltage.configure do |config|
+  config.routes = false
+end

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 HighVoltage.configure do |config|
   config.routes = false
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe DashboardsHelper, type: :helper do
       before { registration.tier = "UPPER" }
 
       context "when a renewal is possible" do
-        before { allow_any_instance_of(WasteCarriersEngine::TransientRegistration).to receive(:can_be_renewed?).and_return(true) }
+        before { allow_any_instance_of(WasteCarriersEngine::RenewingRegistration).to receive(:can_be_renewed?).and_return(true) }
 
         it "returns true" do
           expect(helper.display_renew_link_for?(registration)).to eq(true)
@@ -90,7 +90,7 @@ RSpec.describe DashboardsHelper, type: :helper do
       end
 
       context "when a renewal is not possible" do
-        before { allow_any_instance_of(WasteCarriersEngine::TransientRegistration).to receive(:can_be_renewed?).and_return(false) }
+        before { allow_any_instance_of(WasteCarriersEngine::RenewingRegistration).to receive(:can_be_renewed?).and_return(false) }
 
         it "returns false" do
           expect(helper.display_renew_link_for?(registration)).to eq(false)


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-756

Following from: DEFRA/waste-carriers-engine#553

Use RenewingRegistration instead of Transient registration everywhere