### PR TITLE
Add support for mocking external services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
     branch: "master"
 
+gem "defra_ruby_mocks",
+    git: "https://github.com/DEFRA/defra-ruby-mocks",
+    branch: "master"
+
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have
 # access to it to generate a log, and so they are using the same version.

--- a/Gemfile
+++ b/Gemfile
@@ -53,9 +53,15 @@ gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
     branch: "master"
 
-gem "defra_ruby_mocks",
-    git: "https://github.com/DEFRA/defra-ruby-mocks",
-    branch: "master"
+# Use the defra ruby mocks engine to add support for mocking external services
+# in live environment. Essentially with this gem added and enabled the app
+# also becomes a 'mock' for external services like companies house.
+# This then allows us to performance test our services without fear of being
+# reported for causing undue loads on the external services we use.
+# With the environment properly configured, when any app in an environment needs
+# to call Companies House, instead it will call this app which will mock the end
+# point and return the response expected.
+gem "defra_ruby_mocks", "~> 1.0"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/DEFRA/defra-ruby-mocks
+  revision: 77fd432b91ddd6e6ed6a81039e4f962c137f04be
+  branch: master
+  specs:
+    defra_ruby_mocks (0.0.1)
+      rails (~> 4.2.11.1)
+
+GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
   revision: 83c98af77d47acc30aa1d8dcea97ef017b17b0e6
   branch: master
@@ -349,6 +357,7 @@ DEPENDENCIES
   cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   database_cleaner
+  defra_ruby_mocks!
   defra_ruby_style
   devise (>= 4.4.3)
   devise_invitable (~> 1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/defra-ruby-mocks
-  revision: 77fd432b91ddd6e6ed6a81039e4f962c137f04be
+  revision: 1cc464b58d009732872e5a3326c20084bd4808b4
   branch: master
   specs:
     defra_ruby_mocks (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/DEFRA/defra-ruby-mocks
-  revision: 1cc464b58d009732872e5a3326c20084bd4808b4
-  branch: master
-  specs:
-    defra_ruby_mocks (0.0.1)
-      rails (~> 4.2.11.1)
-
-GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
   revision: 83c98af77d47acc30aa1d8dcea97ef017b17b0e6
   branch: master
@@ -96,6 +88,8 @@ GEM
     crass (1.0.5)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
+    defra_ruby_mocks (1.0.0)
+      rails (~> 4.2.11.1)
     defra_ruby_style (0.1.3)
       rubocop (~> 0.75)
     defra_ruby_validators (2.2.0)
@@ -357,7 +351,7 @@ DEPENDENCIES
   cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   database_cleaner
-  defra_ruby_mocks!
+  defra_ruby_mocks (~> 1.0)
   defra_ruby_style
   devise (>= 4.4.3)
   devise_invitable (~> 1.7.0)

--- a/config/initializers/defra_ruby_mocks.rb
+++ b/config/initializers/defra_ruby_mocks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+DefraRubyMocks.configure do |configuration|
+  # Enable the mock routes mounted in this app if the environment is configured
+  # for it
+  configuration.enable = ENV["WCRS_MOCK_ENABLED"] || false
+end

--- a/config/initializers/defra_ruby_mocks.rb
+++ b/config/initializers/defra_ruby_mocks.rb
@@ -4,4 +4,7 @@ DefraRubyMocks.configure do |configuration|
   # Enable the mock routes mounted in this app if the environment is configured
   # for it
   configuration.enable = ENV["WCRS_MOCK_ENABLED"] || false
+  # Set how long the mock should delay before responding. In the engine itself
+  # the default is 1000ms (1 second)
+  configuration.delay = ENV["WCRS_MOCK_DELAY"] || 1000
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,5 @@ Rails.application.routes.draw do
 
   mount WasteCarriersEngine::Engine => "/fo"
 
-  mount DefraRubyMocks::Engine => "/mocks"
+  mount DefraRubyMocks::Engine => "/fo/mocks"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,6 @@ Rails.application.routes.draw do
   get "/fo" => "dashboards#index"
 
   mount WasteCarriersEngine::Engine => "/fo"
+
+  mount DefraRubyMocks::Engine => "/mocks"
 end


### PR DESCRIPTION
We have created a new engine in the DefraRuby namespace called [defra_ruby_mocks](https://github.com/DEFRA/defra-ruby-mocks).

Going forward this will allow us to mock external services like Companies House, and in the future Worldpay.

We only really need to do this when running performance tests. We want to put as much of the service under load as possible, but at the same time we don't want to get into trouble for overloading these external services, or worst case get accused of a DDOS attack.

So by providing an alternate end point that can accept the same request, and return what the service needs, we can replace them when we need to.

For reference we only need to bring mocking support into one app, because we only need one version of the mock endpoint running. And we chose the front-office because we shouldn't get any issues with access permissions from things like white listing.

So this change adds the mocks engine to the app, including the initializer, which for now will give us the ability to mock companies house.