### PR TITLE
Read companies house url from environment

### DIFF
--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -3,4 +3,10 @@
 WasteCarriersEngine.configure do |configuration|
   # Companies house API config
   configuration.companies_house_api_key = ENV["WCRS_COMPANIES_HOUSE_API_KEY"]
+
+  # We only want to alter the companies house URL if mocking is enabled. Else
+  # the url is handled by the defra-ruby-validators gem from the wcr engine
+  if ENV["WCRS_MOCK_ENABLED"].to_s.downcase == "true"
+    configuration.companies_house_host = ENV["WCRS_MOCK_BO_COMPANIES_HOUSE_URL"]
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-817

Prior to this change, though we have an env var that contains the companies house URL it was only needed for the frontend project. The front and back-office projects make use of [defra-ruby-validators(https://.github.com/DEFRA/defra-ruby-validators) for validation of the company registration numbers. It has the URL hardcoded in, though it can be overridden via config.

As it has never changed in our time with these services, the front and back office didn't bother to override it.

Turns out that's an issue when you are trying to replace it with a mock!

So this change is needed to support that. By having the app read the URL from the environment, and then tell the engine this (which in turn tells the validators gem) we can get the front office hitting the mock rather than the real companies house service.

The endpoint we want to hit when mocking is our other [back-office](https://github.com/DEFRA/waste-carriers-back-office) app. We have chosen to do it in this way to avoid the additional complexity of managing and maintaining another service across all our environments (if deployment was simple for us it's not the way we would have gone!)

As both apps need to configure themselves to look at the other in an environment, we can't just update the `WCRS_COMPANIES_HOUSE_URL` as this is shared by everything.

Hence we have added logic to check if mocks are enabled. If they are, we refer to a different env var to get the URL to use. When mocks are not enabled, everything remains as it currently is.