### PR TITLE
Update mocks engine to support Worldpay

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "waste_carriers_engine",
 # With the environment properly configured, when any app in an environment needs
 # to call Companies House, instead it will call this app which will mock the end
 # point and return the response expected.
-gem "defra_ruby_mocks", "~> 1.0"
+gem "defra_ruby_mocks", "~> 1.1"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ DEPENDENCIES
   cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   database_cleaner
-  defra_ruby_mocks (~> 1.0)
+  defra_ruby_mocks (~> 1.1)
   defra_ruby_style
   devise (>= 4.4.3)
   devise_invitable (~> 1.7.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,11 @@ module WasteCarriersFrontOffice
     config.grace_window = ENV["WCRS_REGISTRATION_GRACE_WINDOW"].to_i
 
     # Worldpay
-    config.worldpay_url = ENV["WCRS_WORLDPAY_URL"] || "https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"
+    config.worldpay_url = if ENV["WCRS_MOCK_ENABLED"].to_s.downcase == "true"
+                            ENV["WCRS_MOCK_BO_WORLDPAY_URL"]
+                          else
+                            ENV["WCRS_WORLDPAY_URL"] || "https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"
+                          end
     config.worldpay_admin_code = ENV["WCRS_WORLDPAY_ADMIN_CODE"]
     config.worldpay_merchantcode = ENV["WCRS_WORLDPAY_ECOM_MERCHANTCODE"]
     config.worldpay_username = ENV["WCRS_WORLDPAY_ECOM_USERNAME"]

--- a/config/initializers/defra_ruby_mocks.rb
+++ b/config/initializers/defra_ruby_mocks.rb
@@ -7,4 +7,15 @@ DefraRubyMocks.configure do |configuration|
   # Set how long the mock should delay before responding. In the engine itself
   # the default is 1000ms (1 second)
   configuration.delay = ENV["WCRS_MOCK_DELAY"] || 1000
+
+  # Tell the mocks engine details needed to mock worldpay. These are needed
+  # so it can then generate values that the calling app will verify as valid
+  configuration.worldpay_admin_code = ENV["WCRS_WORLDPAY_ADMIN_CODE"]
+  configuration.worldpay_merchant_code = ENV["WCRS_WORLDPAY_ECOM_MERCHANTCODE"]
+  configuration.worldpay_mac_secret = ENV["WCRS_WORLDPAY_ECOM_MACSECRET"]
+  # Tell the mocks engine what our domain is. For the worldpay mock it needs to
+  # tell a calling app what url to redirect a user to in order to 'mock' the
+  # payment part of the process. But in the environments it runs in it is
+  # impossible for it to determine what to use. So we simply just tell it!
+  configuration.worldpay_domain = File.join(ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002", "/fo/mocks")
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-818

The [defra-ruby-mocks](https://github.com/DEFRA/defra-ruby-mocks) engine that we are using to support mocking external services now supports Worldpay.

This change updates the engine and adds the additional config to allow the front-office to stand in as a mock for Worldpay.