### PR TITLE
Remove delete link from user dashboard

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -34,16 +34,11 @@ module DashboardsHelper
     registration.metaData.ACTIVE? || registration.metaData.PENDING?
   end
 
-  def display_delete_link_for?(registration)
-    registration.metaData.ACTIVE?
-  end
-
   def display_no_action_links?(registration)
     return false if display_view_certificate_link_for?(registration) ||
                     display_edit_link_for?(registration) ||
                     display_renew_link_for?(registration) ||
-                    display_order_cards_link_for?(registration) ||
-                    display_delete_link_for?(registration)
+                    display_order_cards_link_for?(registration)
 
     true
   end
@@ -63,10 +58,6 @@ module DashboardsHelper
   def order_cards_url(registration)
     id = registration["_id"]
     "#{Rails.configuration.wcrs_frontend_url}/your-registration/#{id}/order/order-copy_cards"
-  end
-
-  def delete_url(registration)
-    "#{base_frontend_registration_url(registration)}/confirm_delete"
   end
 
   private

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -129,17 +129,6 @@
                 <% end %>
               </li>
             <% end %>
-            <% if display_delete_link_for?(registration) %>
-              <li>
-                <%= link_to delete_url(registration) do %>
-                  <%= t(".results.actions.delete.link_text") %>
-                  <span class="visually-hidden">
-                    <%= t(".results.actions.delete.visually_hidden_text",
-                          name: registration.company_name) %>
-                  </span>
-                <% end %>
-              </li>
-            <% end %>
           </ul>
         <% end %>
       </div>

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -137,24 +137,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     end
   end
 
-  describe "#display_delete_link_for?" do
-    context "when the registration is active" do
-      before { registration.metaData.status = "ACTIVE" }
-
-      it "returns true" do
-        expect(helper.display_delete_link_for?(registration)).to eq(true)
-      end
-    end
-
-    context "when the registration is not active" do
-      before { registration.metaData.status = "PENDING" }
-
-      it "returns false" do
-        expect(helper.display_delete_link_for?(registration)).to eq(false)
-      end
-    end
-  end
-
   describe "#display_no_action_links?" do
     context "when at least one action link should be displayed" do
       before { allow(helper).to receive(:display_renew_link_for?).and_return(true) }
@@ -170,7 +152,6 @@ RSpec.describe DashboardsHelper, type: :helper do
         allow(helper).to receive(:display_edit_link_for?).and_return(false)
         allow(helper).to receive(:display_renew_link_for?).and_return(false)
         allow(helper).to receive(:display_order_cards_link_for?).and_return(false)
-        allow(helper).to receive(:display_delete_link_for?).and_return(false)
       end
 
       it "returns true" do
@@ -204,13 +185,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     it "returns the correct URL" do
       cards_url = "http://www.example.com/your-registration/#{id}/order/order-copy_cards"
       expect(helper.order_cards_url(registration)).to eq(cards_url)
-    end
-  end
-
-  describe "#delete_url" do
-    it "returns the correct URL" do
-      delete_url = "http://www.example.com/registrations/#{id}/confirm_delete"
-      expect(helper.delete_url(registration)).to eq(delete_url)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-938

We have built a new 'Cease or Revoke' feature into the back-office to replace the existing 'De-register' and 'Revoke' functions in the old backend.

As part of the rebuild, it was agreed with NCCC that we would not build a version for external users; this would be for internal users only in the future. In fact, it was requested this ability be removed from the external-facing sites because of the issues it causes when users mistakenly 'Delete' their registration.

We forgot to remove the old external 'Delete' link at the time. This change rectifies that oversight.