### PR TITLE
Remove Order copy cards link

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -28,17 +28,10 @@ module DashboardsHelper
     transient_registration.can_be_renewed?
   end
 
-  def display_order_cards_link_for?(registration)
-    return false unless registration.tier == "UPPER"
-
-    registration.metaData.ACTIVE? || registration.metaData.PENDING?
-  end
-
   def display_no_action_links?(registration)
     return false if display_view_certificate_link_for?(registration) ||
                     display_edit_link_for?(registration) ||
-                    display_renew_link_for?(registration) ||
-                    display_order_cards_link_for?(registration)
+                    display_renew_link_for?(registration)
 
     true
   end
@@ -53,11 +46,6 @@ module DashboardsHelper
 
   def renew_url(registration)
     WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(registration.reg_identifier)
-  end
-
-  def order_cards_url(registration)
-    id = registration["_id"]
-    "#{Rails.configuration.wcrs_frontend_url}/your-registration/#{id}/order/order-copy_cards"
   end
 
   private

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -118,17 +118,6 @@
                 <% end %>
               </li>
             <% end %>
-            <% if display_order_cards_link_for?(registration) %>
-              <li>
-                <%= link_to order_cards_url(registration) do %>
-                  <%= t(".results.actions.order_cards.link_text") %>
-                  <span class="visually-hidden">
-                    <%= t(".results.actions.order_cards.visually_hidden_text",
-                          name: registration.company_name) %>
-                  </span>
-                <% end %>
-              </li>
-            <% end %>
           </ul>
         <% end %>
       </div>

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -99,44 +99,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     end
   end
 
-  describe "#display_order_cards_link_for?" do
-    context "when the registration is upper tier" do
-      before { registration.tier = "UPPER" }
-
-      context "when the registration is active" do
-        before { registration.metaData.status = "ACTIVE" }
-
-        it "returns true" do
-          expect(helper.display_order_cards_link_for?(registration)).to eq(true)
-        end
-      end
-
-      context "when the registration is pending" do
-        before { registration.metaData.status = "PENDING" }
-
-        it "returns true" do
-          expect(helper.display_order_cards_link_for?(registration)).to eq(true)
-        end
-      end
-
-      context "when the registration is not active or pending" do
-        before { registration.metaData.status = "REVOKED" }
-
-        it "returns false" do
-          expect(helper.display_order_cards_link_for?(registration)).to eq(false)
-        end
-      end
-    end
-
-    context "when the registration is lower tier" do
-      before { registration.tier = "LOWER" }
-
-      it "returns false" do
-        expect(helper.display_order_cards_link_for?(registration)).to eq(false)
-      end
-    end
-  end
-
   describe "#display_no_action_links?" do
     context "when at least one action link should be displayed" do
       before { allow(helper).to receive(:display_renew_link_for?).and_return(true) }
@@ -151,7 +113,6 @@ RSpec.describe DashboardsHelper, type: :helper do
         allow(helper).to receive(:display_view_certificate_link_for?).and_return(false)
         allow(helper).to receive(:display_edit_link_for?).and_return(false)
         allow(helper).to receive(:display_renew_link_for?).and_return(false)
-        allow(helper).to receive(:display_order_cards_link_for?).and_return(false)
       end
 
       it "returns true" do
@@ -178,13 +139,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     it "returns the correct URL" do
       renew_url = "/fo/#{reg_identifier}/renew"
       expect(helper.renew_url(registration)).to eq(renew_url)
-    end
-  end
-
-  describe "#order_cards_url" do
-    it "returns the correct URL" do
-      cards_url = "http://www.example.com/your-registration/#{id}/order/order-copy_cards"
-      expect(helper.order_cards_url(registration)).to eq(cards_url)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-939

We have built a new 'Order copy cards' feature into the back-office to replace the existing 'Order copy cards' feature in the old backend.

As part of the rebuild, it was agreed with NCCC that we would not build a version for external users at this time. Although we have evidence the feature is used, the numbers seem to be marginal so it was agreed we could put off providing an external implementation. This decision made even more sense knowing that the next big changes will be the ability to renew via magic-link, and removal of the account altogether.

Those 2 changes will have a massive impact on the kind of solution that would be needed, so it makes no sense to implement one now only to immediately change it.

NCCC has accepted that all copy card orders will now need to come through them.

By removing the option to order copy cards now, rather than wait till the account is removed altogether we can test if our stats and assumptions are correct (that the impact will be negligible) before removal of the feature is permanent.

It also means that all copy card orders made going forward will be done just using the new process. This will make it easier to support and reduce the chance of issues caused by having two different code bases trying to do the same thing.