### PR TITLE
Add style for blue application received box

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,7 @@
 @import 'partials/pagination';
 @import 'partials/people';
 @import 'partials/published_dates';
+@import 'partials/govuk-box-highlight';
 
 main {
   max-width: 1080px;

--- a/app/assets/stylesheets/partials/_govuk-box-highlight.scss
+++ b/app/assets/stylesheets/partials/_govuk-box-highlight.scss
@@ -1,0 +1,3 @@
+.govuk-box-highlight_blue {
+  background-color: #1d70b8;
+}


### PR DESCRIPTION
In the new wireframe we have new informative boxes with a background blue. This adds the style that is used by views implemented in the engine.