### PR TITLE
Remove Edit link from dashboard search results

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -13,10 +13,6 @@ module DashboardsHelper
     registration.metaData.ACTIVE?
   end
 
-  def display_edit_link_for?(registration)
-    registration.metaData.ACTIVE? || registration.metaData.PENDING?
-  end
-
   def display_renew_link_for?(registration)
     return false unless registration.tier == "UPPER"
 
@@ -30,7 +26,6 @@ module DashboardsHelper
 
   def display_no_action_links?(registration)
     return false if display_view_certificate_link_for?(registration) ||
-                    display_edit_link_for?(registration) ||
                     display_renew_link_for?(registration)
 
     true

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -96,17 +96,6 @@
                 <% end %>
               </li>
             <% end %>
-            <% if display_edit_link_for?(registration) %>
-              <li>
-                <%= link_to edit_url(registration) do %>
-                  <%= t(".results.actions.edit.link_text") %>
-                  <span class="visually-hidden">
-                    <%= t(".results.actions.edit.visually_hidden_text",
-                          name: registration.company_name) %>
-                  </span>
-                <% end %>
-              </li>
-            <% end %>
             <% if display_renew_link_for?(registration) %>
               <li>
                 <%= link_to renew_url(registration) do %>

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -43,32 +43,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     end
   end
 
-  describe "#display_edit_link_for?" do
-    context "when the registration is active" do
-      before { registration.metaData.status = "ACTIVE" }
-
-      it "returns true" do
-        expect(helper.display_edit_link_for?(registration)).to eq(true)
-      end
-    end
-
-    context "when the registration is pending" do
-      before { registration.metaData.status = "PENDING" }
-
-      it "returns true" do
-        expect(helper.display_edit_link_for?(registration)).to eq(true)
-      end
-    end
-
-    context "when the registration is not active or pending" do
-      before { registration.metaData.status = "REVOKED" }
-
-      it "returns false" do
-        expect(helper.display_edit_link_for?(registration)).to eq(false)
-      end
-    end
-  end
-
   describe "#display_renew_link_for?" do
     context "when the registration is lower tier" do
       before { registration.tier = "LOWER" }
@@ -111,7 +85,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     context "when no action links should be displayed" do
       before do
         allow(helper).to receive(:display_view_certificate_link_for?).and_return(false)
-        allow(helper).to receive(:display_edit_link_for?).and_return(false)
         allow(helper).to receive(:display_renew_link_for?).and_return(false)
       end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-981

The design and implementation of the new 'Edit' feature are based on the fact in the future only NCCC will be doing edits. We have agreed with them to remove this option from external users dashboards, as it is something they would prefer to control. Also, the current version is very poorly designed and implemented and leads to users inadvertently de-registering themselves.

So this change removes the link from the dashboard search results.