### PR TITLE
Add data layer to head

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :back_button_cache_buster
 
   helper WasteCarriersEngine::ApplicationHelper
+  helper WasteCarriersEngine::DataLayerHelper
 
   # Within our production 'like' environments access to the app can only be
   # obtained through `/fo`. Therefore to make this clear and ensure there is

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,12 @@
 <% content_for(:head) do %>
+  <% if @transient_registration.present? %>
+    <script>
+      dataLayer = [{
+        <%= data_layer(@transient_registration) %>
+      }];
+    </script>
+  <% end %>
+
   <% if ENV['GOOGLE_TAGMANAGER_ID'].present? %>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-950

We want to be able to track the performance of the new registration journey and the renewals journey. Because they use the same pages, we'll need a different way to differentiate.

This PR will add a data layer to the front office header. This will be used by Google Tag Manager to send pageviews with the journey as a custom dimension to Google Analytics.