### PR TITLE
Remove options from bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ services:
 
 before_install:
   - export TZ=UTC
-  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
+  - gem install -v 1.17.3 bundler
 
 before_script:
   # Set up Mongo databases


### PR DESCRIPTION
Problem: 
Since last week all our builds are failing. 
The main error is:
```
$ gem install -v 1.17.3 bundler --no-rdoc --no-ri
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
The command "gem install -v 1.17.3 bundler --no-rdoc --no-ri" failed and exited with 1 during .
```
Visibile in: https://travis-ci.com/github/DEFRA/waste-exemptions-engine/builds/166643334

The only difference in our builds, seems to be in the binary version of ruby that travis install. Before the breakage, we could observe from the logs that we were installing ruby from https://rubies.travis-ci.org/ubuntu/14.04/x86_64/ruby-2.4.2.tar.bz2  (https://travis-ci.com/github/DEFRA/waste-exemptions-engine/builds/165727465)
When the breakage started happening, we could observe that the ruby version installed by RVM came from https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.3.1.tar.bz2 

Fro now, to unblock our work, we are removing the options that cause the error.