### PR TITLE
Remove references to Mailinator in seeded data

### DIFF
--- a/db/seeds/CBDU212.json
+++ b/db/seeds/CBDU212.json
@@ -11,7 +11,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "wcr-user@mailinator.com",
+  "contactEmail": "wcr-user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -48,7 +48,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "wcr-user@mailinator.com",
+  "accountEmail": "wcr-user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU212",

--- a/db/seeds/CBDU219.json
+++ b/db/seeds/CBDU219.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "wcr-user@mailinator.com",
+  "contactEmail": "wcr-user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "wcr-user@mailinator.com",
+  "accountEmail": "wcr-user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU219",

--- a/db/seeds/CBDU225.json
+++ b/db/seeds/CBDU225.json
@@ -10,7 +10,7 @@
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
-  "contactEmail": "wcr-user@mailinator.com",
+  "contactEmail": "wcr-user@example.com",
   "addresses": [{
       "addressType": "REGISTERED",
       "addressMode": "manual-uk",
@@ -47,7 +47,7 @@
       "confirmed": "no"
     }
   }],
-  "accountEmail": "wcr-user@mailinator.com",
+  "accountEmail": "wcr-user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU225",

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -4,7 +4,7 @@
       "email": "user@example.com"
     },
     {
-      "email": "wcr-user@mailinator.com"
+      "email": "wcr-user@example.com"
     },
     {
       "email": "another-user@example.com"


### PR DESCRIPTION
We are currently [updating the acceptance tests to use the built-in last-email API](https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/315) rather than external services such as mailinator and mailcatcher, so that they run consistently across environments.

The seeded data in this repo also contains references to mailinator, so it makes sense to remove them and update the relevant tests accordingly.