### PR TITLE
Allow front office users to view their certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   global:
     - WCRS_REGISTRATION_EXPIRES_AFTER=3
     - WCRS_REGISTRATION_RENEWAL_WINDOW=3
+    - WCRS_USE_XVFB_FOR_WICKEDPDF=true
 
 services:
   - mongodb
@@ -25,6 +26,9 @@ services:
 before_install:
   - export TZ=UTC
   - gem install -v 1.17.3 bundler
+  - sudo apt-get install xvfb -y
+  - sudo apt-get install ttf-liberation -y
+  - sudo apt-get install wkhtmltopdf -y
 
 before_script:
   # Set up Mongo databases

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "kaminari-mongoid", "~> 1.0"
 
 gem "secure_headers", "~> 5.0"
 
+gem "wicked_pdf"
+
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   waste_carriers_engine!
   web-console (~> 2.0)
+  wicked_pdf
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,4 +38,8 @@ class ApplicationController < ActionController::Base
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
+
+  rescue_from CanCan::AccessDenied do
+    redirect_to "/fo/pages/permission"
+  end
 end

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -3,6 +3,8 @@
 class CertificatesController < ApplicationController
   include CanRenderPdf
 
+  before_action :authenticate_user!
+
   def show
     registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
     @presenter = WasteCarriersEngine::CertificatePresenter.new(registration, view_context)

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -7,6 +7,9 @@ class CertificatesController < ApplicationController
 
   def show
     registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+
+    authorize! :read, registration
+
     @presenter = WasteCarriersEngine::CertificatePresenter.new(registration, view_context)
 
     render pdf: registration.reg_identifier,

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CertificatesController < ApplicationController
+  include CanRenderPdf
+
+  def show
+    registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+    @presenter = WasteCarriersEngine::CertificatePresenter.new(registration, view_context)
+
+    render pdf: registration.reg_identifier,
+           show_as_html: show_as_html?,
+           layout: false,
+           page_size: "A4",
+           margin: { top: "10mm", bottom: "10mm", left: "10mm", right: "10mm" },
+           print_media_type: true,
+           template: "waste_carriers_engine/pdfs/certificate"
+  end
+end

--- a/app/controllers/concerns/can_render_pdf.rb
+++ b/app/controllers/concerns/can_render_pdf.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CanRenderPdf
+  extend ActiveSupport::Concern
+
+  def show_as_html?
+    params[:show_as_html] == "true"
+  end
+end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -35,10 +35,6 @@ module DashboardsHelper
     certificate_path(registration.reg_identifier)
   end
 
-  def edit_url(registration)
-    "#{base_frontend_registration_url(registration)}/edit"
-  end
-
   def renew_url(registration)
     WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(registration.reg_identifier)
   end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -32,7 +32,7 @@ module DashboardsHelper
   end
 
   def view_certificate_url(registration)
-    "#{base_frontend_registration_url(registration)}/view"
+    certificate_path(registration.reg_identifier)
   end
 
   def edit_url(registration)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,6 @@ Rails.application.routes.draw do
     put   "/fo/users/invitation/accept" => "invitations#update"
   end
 
-
   get "/fo/registrations/:reg_identifier/certificate", to: "certificates#show", as: :certificate
 
   get "/fo" => "dashboards#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
     put   "/fo/users/invitation/accept" => "invitations#update"
   end
 
+
+  get "/fo/registrations/:reg_identifier/certificate", to: "certificates#show", as: :certificate
+
   get "/fo" => "dashboards#index"
 
   mount WasteCarriersEngine::Engine => "/fo"

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :metaData, class: WasteCarriersEngine::MetaData do
     date_registered { Time.current }
+    date_activated { Time.current }
   end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -101,13 +101,6 @@ RSpec.describe DashboardsHelper, type: :helper do
     end
   end
 
-  describe "#edit_url" do
-    it "returns the correct URL" do
-      edit_url = "http://www.example.com/registrations/#{id}/edit"
-      expect(helper.edit_url(registration)).to eq(edit_url)
-    end
-  end
-
   describe "#renew_url" do
     it "returns the correct URL" do
       renew_url = "/fo/#{reg_identifier}/renew"

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe DashboardsHelper, type: :helper do
 
   describe "#view_certificate_url" do
     it "returns the correct URL" do
-      certificate_url = "http://www.example.com/registrations/#{id}/view"
+      certificate_url = "/fo/registrations/#{reg_identifier}/certificate"
       expect(helper.view_certificate_url(registration)).to eq(certificate_url)
     end
   end

--- a/spec/requests/certificates_spec.rb
+++ b/spec/requests/certificates_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Certificates", type: :request do
+  let(:user) { create(:user) }
+  let(:registration) { create(:registration, :expires_soon, account_email: user.email) }
+  before(:each) do
+    sign_in(user)
+  end
+
+  describe "GET /fo/registrations/:reg_identifier/certificate/" do
+    it "responds with a PDF with a filename that includes the registration reference" do
+      get "/fo/registrations/#{registration.reg_identifier}/certificate"
+
+      expect(response.content_type).to eq("application/pdf")
+      expected_content_disposition = "inline; filename=\"#{registration.reg_identifier}.pdf\""
+      expect(response.headers["Content-Disposition"]).to eq(expected_content_disposition)
+    end
+
+    it "returns a 200 status code" do
+      get "/fo/registrations/#{registration.reg_identifier}/certificate"
+      expect(response.code).to eq("200")
+    end
+
+    context "when the 'show_as_html' query string is present" do
+      context "and the value is 'true'" do
+        it "responds with HTML" do
+          get "/fo/registrations/#{registration.reg_identifier}/certificate?show_as_html=true"
+          expect(response.content_type).to eq("text/html")
+        end
+      end
+
+      [false, 1, 0, :foo].each do |bad_value|
+        context "and the value is '#{bad_value}'" do
+          it "responds with a PDF" do
+            get "/fo/registrations/#{registration.reg_identifier}/certificate?show_as_html=#{bad_value}"
+            expect(response.content_type).to eq("application/pdf")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/certificates_spec.rb
+++ b/spec/requests/certificates_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe "Certificates", type: :request do
       end
     end
 
+    context "when a different user is logged in" do
+      before(:each) do
+        sign_in(create(:user))
+      end
+
+      it "redirects to the permissions error" do
+        get "/fo/registrations/#{registration.reg_identifier}/certificate"
+        expect(response).to redirect_to("/fo/pages/permission")
+      end
+    end
+
     context "when no user is logged in" do
       it "redirects to the sign-in page" do
         get "/fo/registrations/#{registration.reg_identifier}/certificate"

--- a/spec/requests/certificates_spec.rb
+++ b/spec/requests/certificates_spec.rb
@@ -5,39 +5,49 @@ require "rails_helper"
 RSpec.describe "Certificates", type: :request do
   let(:user) { create(:user) }
   let(:registration) { create(:registration, :expires_soon, account_email: user.email) }
-  before(:each) do
-    sign_in(user)
-  end
 
   describe "GET /fo/registrations/:reg_identifier/certificate/" do
-    it "responds with a PDF with a filename that includes the registration reference" do
-      get "/fo/registrations/#{registration.reg_identifier}/certificate"
-
-      expect(response.content_type).to eq("application/pdf")
-      expected_content_disposition = "inline; filename=\"#{registration.reg_identifier}.pdf\""
-      expect(response.headers["Content-Disposition"]).to eq(expected_content_disposition)
-    end
-
-    it "returns a 200 status code" do
-      get "/fo/registrations/#{registration.reg_identifier}/certificate"
-      expect(response.code).to eq("200")
-    end
-
-    context "when the 'show_as_html' query string is present" do
-      context "and the value is 'true'" do
-        it "responds with HTML" do
-          get "/fo/registrations/#{registration.reg_identifier}/certificate?show_as_html=true"
-          expect(response.content_type).to eq("text/html")
-        end
+    context "when the user who owns the registration is logged in" do
+      before(:each) do
+        sign_in(user)
       end
 
-      [false, 1, 0, :foo].each do |bad_value|
-        context "and the value is '#{bad_value}'" do
-          it "responds with a PDF" do
-            get "/fo/registrations/#{registration.reg_identifier}/certificate?show_as_html=#{bad_value}"
-            expect(response.content_type).to eq("application/pdf")
+      it "responds with a PDF with a filename that includes the registration reference" do
+        get "/fo/registrations/#{registration.reg_identifier}/certificate"
+
+        expect(response.content_type).to eq("application/pdf")
+        expected_content_disposition = "inline; filename=\"#{registration.reg_identifier}.pdf\""
+        expect(response.headers["Content-Disposition"]).to eq(expected_content_disposition)
+      end
+
+      it "returns a 200 status code" do
+        get "/fo/registrations/#{registration.reg_identifier}/certificate"
+        expect(response.code).to eq("200")
+      end
+
+      context "when the 'show_as_html' query string is present" do
+        context "and the value is 'true'" do
+          it "responds with HTML" do
+            get "/fo/registrations/#{registration.reg_identifier}/certificate?show_as_html=true"
+            expect(response.content_type).to eq("text/html")
           end
         end
+
+        [false, 1, 0, :foo].each do |bad_value|
+          context "and the value is '#{bad_value}'" do
+            it "responds with a PDF" do
+              get "/fo/registrations/#{registration.reg_identifier}/certificate?show_as_html=#{bad_value}"
+              expect(response.content_type).to eq("application/pdf")
+            end
+          end
+        end
+      end
+    end
+
+    context "when no user is logged in" do
+      it "redirects to the sign-in page" do
+        get "/fo/registrations/#{registration.reg_identifier}/certificate"
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1130

The front office dashboard includes a link to view certificates, but this currently goes to the old frontend.

Since the frontend should be decommissioned before we remove accounts, we'll need to move this feature for now.

This PR adds the ability to view certificates for logged-in users.