### PR TITLE
Update dashboard 'change password' link

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PasswordsController < ApplicationController
+
+  before_action :authenticate_user!
+  before_action :assign_user
+
+  def edit; end
+
+  def update
+    if @user.update_with_password(user_params)
+      bypass_sign_in(@user)
+      redirect_to root_path
+    else
+      render "edit"
+    end
+  end
+
+  private
+
+  def assign_user
+    @user = current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
+end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -2,7 +2,7 @@
 
 module DashboardsHelper
   def url_to_change_password
-    "#{Rails.configuration.wcrs_frontend_url}/users/edit"
+    edit_passwords_path
   end
 
   def url_for_new_registration

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,41 @@
+<div class="text">
+  <h1 class="heading-large"><%= t(".header") %></h1>
+
+  <%= form_for(@user, url: passwords_path) do |f| %>
+    <%= render("waste_carriers_engine/shared/errors", object: @user) %>
+
+    <p>
+      <%= t(".password_guidance") %>
+    </p>
+
+    <div class="form-group <%= "form-group-error" if @user.errors[:current_password].any? %>">
+      <fieldset id="current_password">
+        <%= f.label :current_password, class: "form-label" do %>
+          <%= t(".labels.current_password") %>
+          <span class="form-hint">
+          <%= t(".labels.current_password_hint") %>
+          </span>
+        <% end %>
+        <%= f.password_field :current_password, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <div class="form-group <%= "form-group-error" if @user.errors[:password].any? %>">
+      <fieldset id="password">
+        <%= f.label :password, t(".labels.password"), class: "form-label" %>
+        <%= f.password_field :password, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <div class="form-group <%= "form-group-error" if @user.errors[:password_confirmation].any? %>">
+      <fieldset id="password_confirmation">
+        <%= f.label :password_confirmation, t(".labels.password_confirmation"), class: "form-label" %>
+        <%= f.password_field :password_confirmation, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <div class="actions">
+      <%= f.submit t(".submit_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,13 @@ en:
       models:
         user:
           attributes:
+            current_password:
+              blank: "You must enter your current password"
+              invalid: "You must enter a valid current password"
             password:
               blank: "You must enter a password"
               too_short: "The password must be at least 8 characters long"
               invalid_format: "The password must contain uppercase letters, lowercase letters and numbers"
+            password_confirmation:
+              blank: "You must confirm your password"
+              confirmation: "The password confirmation must match the new password"

--- a/config/locales/passwords.en.yml
+++ b/config/locales/passwords.en.yml
@@ -1,0 +1,11 @@
+en:
+  passwords:
+    edit:
+      header: "Change your password"
+      password_guidance: "Your password must be at least 8 characters long and contain uppercase letters, lowercase letters and numbers."
+      labels:
+        current_password: "Enter your current password"
+        current_password_hint: "We need your current password to confirm your changes"
+        password: "Enter your new password"
+        password_confirmation: "Confirm your new password"
+      submit_button: "Submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,12 @@ Rails.application.routes.draw do
     get   "/fo/users/invitation/accept" => "invitations#edit", as: :accept_user_invitation
     patch "/fo/users/invitation/accept" => "invitations#update", as: :user_invitation
     put   "/fo/users/invitation/accept" => "invitations#update"
+
+    # Used for editing user passwords when they are already logged in
+    resource :passwords,
+             only: %i[edit update],
+             path: "/fo/users/edit-password",
+             path_names: { edit: "" }
   end
 
   get "/fo/registrations/:reg_identifier/certificate", to: "certificates#show", as: :certificate

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DashboardsHelper, type: :helper do
 
   describe "#url_to_change_password" do
     it "returns the correct URL" do
-      password_url = "http://www.example.com/users/edit"
+      password_url = "/fo/users/edit-password"
       expect(helper.url_to_change_password).to eq(password_url)
     end
   end

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Passwords", type: :request do
+  describe "GET /fo/users/edit-password" do
+    context "when the user is not signed in" do
+      it "redirects the user to the sign in page" do
+        get "/fo/users/edit-password"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when the user is signed in" do
+      let(:user) { create(:user) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "loads the change password page" do
+        get "/fo/users/edit-password"
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template("passwords/edit")
+        expect(response.body).to include("Change your password")
+      end
+    end
+  end
+
+  describe "PATCH /fo/users/edit-password" do
+    let(:user) { create(:user) }
+
+    context "when the user is not signed in" do
+      it "redirects the user to the sign in page" do
+        patch "/fo/users/edit-password"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when the user is signed in" do
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when valid params are submitted" do
+        let(:params) do
+          {
+            user:
+            {
+              current_password: user.password,
+              password: "AcceptablePassword123",
+              confirm_password: "AcceptablePassword123"
+            }
+          }
+        end
+
+        it "updates the password and redirects to the root" do
+          old_password = user.password
+
+          patch "/fo/users/edit-password", params: params
+
+          expect(user.reload.password).to_not eq(old_password)
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context "when invalid params are submitted" do
+        let(:params) do
+          {
+            user:
+            {
+              current_password: user.password,
+              password: "foo",
+              confirm_password: "bar"
+            }
+          }
+        end
+
+        it "does not update the password and redirects to the edit page" do
+          old_password = user.encrypted_password
+
+          patch "/fo/users/edit-password", params: params
+
+          expect(user.reload.encrypted_password).to eq(old_password)
+          expect(response).to have_http_status(200)
+          expect(response).to render_template("passwords/edit")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1129

This previously linked to the password change functionality in the old frontend. It should go to the front office instead.

It turns out that the existing "reset password" function for users who are not logged in could not be reused here - this is specifically for un-authed users, and if you want to use Devise to let logged-in users edit their details, it comes as part of the 'registerable' module. We don't want all of the baggage that comes with that (ie users being able to create their own accounts at will, or edit other account values) so after consulting the docs, the most straightforward option was just to make our own.

Reference: https://github.com/heartcombo/devise/wiki/How-To:-Allow-users-to-edit-their-password