### PR TITLE
Update defra-ruby-alert to use blocklist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 3310afc2ea8848605f702532e7f25a1ac56fb9ab
+  revision: 47f438230915458d397b1ca37303021e5be7cc19
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
       countries
       defra_ruby_address
-      defra_ruby_alert (~> 2.0.0)
+      defra_ruby_alert (~> 2.1)
       defra_ruby_email
       defra_ruby_validators
       high_voltage (~> 3.0)
@@ -106,7 +106,7 @@ GEM
     database_cleaner (1.8.5)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
-    defra_ruby_alert (2.0.0)
+    defra_ruby_alert (2.1.1)
       airbrake
     defra_ruby_email (1.0.0)
       rails (~> 6.0.3.1)

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -20,7 +20,7 @@ WasteCarriersEngine.configure do |configuration|
   configuration.airbrake_enabled = ENV["WCRS_USE_AIRBRAKE"]
   configuration.airbrake_host = ENV["WCRS_AIRBRAKE_URL"]
   configuration.airbrake_project_key = ENV["WCRS_FRONTOFFICE_AIRBRAKE_PROJECT_KEY"]
-  configuration.airbrake_blacklist = [/password/i, /authorization/i]
+  configuration.airbrake_blocklist = [/password/i, /authorization/i]
 
   configuration.address_host = ENV["ADDRESSBASE_URL"] || "http://localhost:8005"
 end


### PR DESCRIPTION
https://github.com/DEFRA/defra-ruby-alert/pull/10

With Airbrake changing the name `blacklist` to `blocklist` (quite rightly) we updated our config in defra-ruby-alert so in turn the config in the engine.

This updates the front-office to work with this change.