### PR TITLE
Redirect to /fo after password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -10,7 +10,7 @@ class PasswordsController < ApplicationController
   def update
     if @user.update_with_password(user_params)
       bypass_sign_in(@user)
-      redirect_to root_path
+      redirect_to fo_path
     else
       render "edit"
     end

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Passwords", type: :request do
           }
         end
 
-        it "updates the password and redirects to the /fo" do
+        it "updates the password and redirects to /fo" do
           old_password = user.password
 
           patch "/fo/users/edit-password", params: params

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe "Passwords", type: :request do
           }
         end
 
-        it "updates the password and redirects to the root" do
+        it "updates the password and redirects to the /fo" do
           old_password = user.password
 
           patch "/fo/users/edit-password", params: params
 
           expect(user.reload.password).to_not eq(old_password)
           expect(response).to have_http_status(302)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(fo_path)
         end
       end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1129

When we implemented the password edit in [PR #559](https://github.com/DEFRA/waste-carriers-front-office/pull/559) we had it redirect to root after the POST.

Locally this would redirect to the dashboard. But when testing in AWS it was redirecting to `/fo/start`. When investigating this was because `root_path()` was returning `/` and in our AWS environments if `/fo` is not at the start of the path it will direct the request to the old frontend app.

However, that now also has an automatic redirect to `/fo/start`. So this is why it looks like the change password screen is redirecting to the new registration start screen.

This change tells the passwords controller to redirect to `/fo` after submission. If the user is signed in this will return them to the dashboard. If not it will send them to the sign-in page.