### PR TITLE
Direct 'New registration' btn based on ft. toggle

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -6,7 +6,11 @@ module DashboardsHelper
   end
 
   def url_for_new_registration
-    "#{Rails.configuration.wcrs_frontend_url}/registrations/find"
+    if WasteCarriersEngine::FeatureToggle.active?(:new_registration)
+      WasteCarriersEngine::Engine.routes.url_helpers.new_start_form_path
+    else
+      File.join(Rails.configuration.wcrs_frontend_url, "registrations/start")
+    end
   end
 
   def display_view_certificate_link_for?(registration)

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -19,9 +19,26 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#url_for_new_registration" do
-    it "returns the correct URL" do
-      registration_url = "http://www.example.com/registrations/find"
-      expect(helper.url_for_new_registration).to eq(registration_url)
+    before(:each) do
+      allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:new_registration) { feature_enabled }
+    end
+
+    context "when the 'new_registration' feature is enabled" do
+      let(:feature_enabled) { true }
+
+      it "returns the correct URL" do
+        registration_url = "/fo/start"
+        expect(helper.url_for_new_registration).to eq(registration_url)
+      end
+    end
+
+    context "when the 'new_registration' feature is not enabled" do
+      let(:feature_enabled) { false }
+
+      it "returns the correct URL" do
+        registration_url = "http://www.example.com/registrations/start"
+        expect(helper.url_for_new_registration).to eq(registration_url)
+      end
     end
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1133

Raised as an issue to do with what happens if a user's session has expired on the old frontend having signed in via it to the front-office. If they then click the 'New registration' button they see a 'Your session has expired' message...or so we have been told 😄

This may indeed be correct though we are currently struggling to replicate it. However, what is definitely wrong is that the 'New registration' button should be directing users directly to the front-office new registration path (`/fo/start`) assuming the `new_registration` feature toggle has been enabled.

It should only direct users to the old app if the feature toggle has not been enabled, which we intend to only happen if some major issue is found with it after release.

So this change updates the logic in the view to ensure that the 'New registration' button has the right path set based on the `new_registration` feature toggle.