### PR TITLE
Make privacy policy on front office match engine

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -22,10 +22,11 @@
     The personal data we collect about you includes:
   </p>
   <ul class="list list-bullet">
-    <li>the name and address of your business or organisation</li>
-    <li>contact details</li>
-    <li>date of birth</li>
-    <li>details of relevant criminal convictions</li>
+    <li>your name and address, if you are applying as an individual or part of a partnership</li>
+    <li>your business’s name and address, if you are applying on behalf of an organisation</li>
+    <li>contact details such as telephone number and email address</li>
+    <li>date of birth of the applicant, directors or partners in the business</li>
+    <li>details of relevant criminal convictions of the applicant, directors or partners</li>
   </ul>
   <p>
     We are allowed to process your personal data because we have official authority to register waste carriers, brokers and dealers. The lawful basis for processing your personal data is to exercise our official authority that is set out in law.
@@ -48,6 +49,9 @@
     We put some of the information from your registration on a public register. Only the name and address of your organisation will appear on the public register.
   </p>
   <p>
+    We share some necessary personal data with our data processors to arrange delivery of registration cards, process financial information and update the public register.
+  </p>
+  <p>
     We will not share or disclose any further personal data to any party outside the Environment Agency without your explicit consent unless we are lawfully able to do so.
   </p>
   <p>
@@ -64,7 +68,7 @@
     Personal data in an upper-tier registration is kept for 7 years after a registration has ended.
   </p>
   <p>
-    Lower-tier registrations are non-expiring, and personal data is retained unless you request it is removed. To request that your personal data is removed, please contact the Environment Agency helpline on 03708 506 506.
+    Lower-tier registrations are non-expiring. If you need to cancel your registration please contact the Environment Agency helpline on 03708 506 506. We will then retain your personal data for 7 years after you have cancelled your registration.
   </p>
 
   <h2 class="heading-medium">
@@ -95,6 +99,6 @@
     You have the right to <a rel="external" href="https://ico.org.uk/make-a-complaint">lodge a complaint with the ICO</a> at any time.
   </p>
   <div class="app-c-published-dates">
-    This notice was last updated on 25 April 2019.
+    This notice was last updated on 5 October 2020.
   </div>
 </div>


### PR DESCRIPTION
This PR updates the front office privacy policy to match the changes made in https://github.com/DEFRA/waste-carriers-engine/pull/911 , as the changes have not yet been applied to front office.

The date will need to be updated here and on the engine when the RFC is raised.

(Question for a separate PR: why do we need to maintain two identical versions?)