### PR TITLE
Redirect old frontend routes to front office pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
 
-  root to: "application#redirect_root_to_dashboard"
+  root to: "waste_carriers_engine/start_forms#new"
 
   devise_for :users,
              controllers: { sessions: "sessions" },
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
   get "/fo/registrations/:reg_identifier/certificate", to: "certificates#show", as: :certificate
 
   get "/fo" => "dashboards#index"
+
+  # Redirect old Devise routes
+  get "/users(*all)" => redirect("/fo/users%{all}")
 
   mount WasteCarriersEngine::Engine => "/fo"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,9 @@ Rails.application.routes.draw do
   get "/fo" => "dashboards#index"
 
   # Redirect old Devise routes
+  # rubocop:disable Style/FormatStringToken
   get "/users(*all)" => redirect("/fo/users%{all}")
+  # rubocop:enable Style/FormatStringToken
 
   mount WasteCarriersEngine::Engine => "/fo"
 

--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -4,27 +4,21 @@ require "rails_helper"
 
 RSpec.describe "Root", type: :request do
   describe "GET /" do
-    it "redirects to /fo" do
+    it "returns a 200 and loads /fo/start" do
       get "/"
-      expect(response).to redirect_to(fo_path)
-    end
 
-    it "returns a 302 (redirect) response" do
-      get "/"
-      expect(response).to have_http_status(302)
+      expect(response).to have_http_status(200)
+      expect(response.body).to include("Is this a new registration?")
     end
   end
 
   describe "GET /fo/renew/[registration number]" do
     context "when the user is not signed in" do
       let(:registration) { create(:registration, reg_identifier: "CBDU12345") }
-      it "returns a 200 response" do
+      it "returns a 302 response and redirects the user to the sign in page" do
         get "/fo/CBDU12345/renew"
-        expect(response).to have_http_status(302)
-      end
 
-      it "redirects the user to the sign in page" do
-        get "/fo/CBDU12345/renew"
+        expect(response).to have_http_status(302)
         expect(response).to redirect_to(new_user_session_path)
       end
 
@@ -50,14 +44,31 @@ RSpec.describe "Root", type: :request do
         sign_in(user)
       end
 
-      it "returns a 200 response" do
+      it "returns a 200 response and loads the renewal start page" do
         get "/fo/#{registration.reg_identifier}/renew"
-        expect(response).to have_http_status(200)
-      end
 
-      it "redirects the user to the renewal start page" do
-        get "/fo/#{registration.reg_identifier}/renew"
+        expect(response).to have_http_status(200)
         expect(response.body).to include("You are about to renew your registration")
+      end
+    end
+  end
+
+  describe "GET /users" do
+    context "when the user goes to an old Devise sign-in URL" do
+      it "returns a 301 and loads the new Devise URL" do
+        get "/users/sign_in"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/fo/users/sign_in")
+      end
+    end
+
+    context "when the user goes to an old Devise password URL" do
+      it "returns a 301 and loads the new Devise URL" do
+        get "/users/password/edit"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/fo/users/password/edit")
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1221

Since the frontend is being removed and the front office will be reached from the subdomain by default, we need to make some redirects.

The root will now go to /fo/start. Old Devise URLs (eg logging in) will redirect to the updated front office URLs.

Also cleaned up the specs a bit.