### PR TITLE
Swap to Mongoid-specific DB-cleaning gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ group :development do
 end
 
 group :test do
-  gem "database_cleaner"
+  gem "database_cleaner-mongoid"
   gem "factory_bot_rails"
   gem "rails-controller-testing"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,10 @@ GEM
       sixarm_ruby_unaccent (~> 1.1)
       unicode_utils (~> 1.4)
     crass (1.0.6)
-    database_cleaner (1.8.5)
+    database_cleaner-core (2.0.1)
+    database_cleaner-mongoid (2.0.1)
+      database_cleaner-core (~> 2.0.0)
+      mongoid
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
     defra_ruby_alert (2.1.1)
@@ -401,7 +404,7 @@ DEPENDENCIES
   aws-healthcheck
   byebug
   cancancan (~> 1.10)
-  database_cleaner
+  database_cleaner-mongoid
   defra_ruby_mocks
   defra_ruby_style
   devise (>= 4.4.3)

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 # Require this to support automatically cleaning the database when testing
-require "database_cleaner"
+require "database_cleaner-mongoid"
 
 RSpec.configure do |config|
   # Clean the registrations and users databases before running tests
   config.before(:suite) do
-    DatabaseCleaner[:mongoid].strategy = :truncation
-    DatabaseCleaner[:mongoid, { connection: :users }].strategy = :truncation
+    DatabaseCleaner[:mongoid].strategy = :deletion
+    DatabaseCleaner[:mongoid, { db: :users }].strategy = :deletion
 
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
We used to use the generic database_cleaner gem but this is now moving in the direction of having ORM-specific gems. ~2.0 updates were failing so it's time to swap.