### PR TITLE
Change size of heading on cookies page

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -55,7 +55,7 @@
         </div>
       </fieldset>
     </div>
-    <h2 class="govuk-heading-m"><%= t('.essential_cookies.subheading') %></h2>
+    <h2 class="govuk-body govuk-!-font-weight-bold"><%= t('.essential_cookies.subheading') %></h2>
     <p class="govuk-body"><%= t('.essential_cookies.text_1') %></p>
     <p class="govuk-body"><%= t('.essential_cookies.text_2') %></p>
     <table class="govuk-table">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1535

"Cookies that measure website use" and "Strictly necessary cookies" should be the same size.