### PR TITLE
Enable mock mode for Rails.config.companies_house_host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,8 +53,14 @@ module WasteCarriersFrontOffice
     config.airbrake_key = ENV["WCRS_FRONTOFFICE_AIRBRAKE_PROJECT_KEY"] || "dummy"
 
     # Companies House config
-    config.companies_house_host = ENV["WCRS_COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
     config.companies_house_api_key = ENV["WCRS_COMPANIES_HOUSE_API_KEY"]
+
+    config.companies_house_host =
+      if ENV["WCRS_MOCK_ENABLED"].to_s.downcase == "true"
+        ENV["WCRS_MOCK_BO_COMPANIES_HOUSE_URL"]
+      else
+        ENV["WCRS_COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
+      end
 
     # Paths
     config.wcrs_renewals_url = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"


### PR DESCRIPTION
- `Rails.config.companies_house_host` is used in the `DefraRubyCompaniesHouse` class

https://eaflood.atlassian.net/browse/RUBY-1855