### PR TITLE
Use main engine branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "wicked_pdf"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "govpay"
+    branch: "main"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: f1776b30a4ec717aa22069d7d1ee3c174945b38f
-  branch: govpay
+  revision: d814858d4dfda03a2fae7994d924af329a65cdba
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)


### PR DESCRIPTION
This corrects the engine branch to main instead of govpay.
https://eaflood.atlassian.net/browse/RUBY-2117