### PR TITLE
Rename wcrs_renewals_url config variable to wcrs_fo_link_domain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 34fc9435d49a260a64e846f2bae7fb96f4856e6e
+  revision: a02edec6887e3bb3261edbfdaad251f17af9f532
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -293,7 +293,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.0)
+    nokogiri (1.14.1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,11 +63,13 @@ module WasteCarriersFrontOffice
       end
 
     # Paths
-    config.wcrs_renewals_url = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
+    # This is the domain to use on URLs for FO services such as renewal and deregistration
+    config.wcrs_fo_link_domain = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
+
     config.wcrs_frontend_url = ENV["WCRS_FRONTEND_DOMAIN"] || "http://localhost:3000"
     config.wcrs_services_url = ENV["WCRS_SERVICES_DOMAIN"] || "http://localhost:8003"
     config.os_places_service_url = ENV["WCRS_OS_PLACES_DOMAIN"] || "http://localhost:8005"
-    config.host = config.wcrs_renewals_url
+    config.host = config.wcrs_fo_link_domain
 
     # Fees
     config.renewal_charge = ENV["WCRS_RENEWAL_CHARGE"].to_i

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   end
 
   # Sending e-mails is required for user management and registration e-mails
-  config.action_mailer.default_url_options = { host: config.wcrs_renewals_url, protocol: "http" }
+  config.action_mailer.default_url_options = { host: config.wcrs_fo_link_domain, protocol: "http" }
 
   # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     user_name: ENV.fetch("WCRS_EMAIL_USERNAME", nil),
     password: ENV.fetch("WCRS_EMAIL_PASSWORD", nil),
-    domain: config.wcrs_renewals_url,
+    domain: config.wcrs_fo_link_domain,
     address: ENV["WCRS_EMAIL_HOST"] || "localhost",
     port: ENV["WCRS_EMAIL_PORT"] || 1025,
     authentication: :plain,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   config.log_formatter = Logger::Formatter.new
 
   # Sending e-mails is required for user management and registration e-mails
-  config.action_mailer.default_url_options = { host: config.wcrs_renewals_url, protocol: "http" }
+  config.action_mailer.default_url_options = { host: config.wcrs_fo_link_domain, protocol: "http" }
 
   # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false
@@ -92,7 +92,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     user_name: ENV.fetch("WCRS_EMAIL_USERNAME", nil),
     password: ENV.fetch("WCRS_EMAIL_PASSWORD", nil),
-    domain: config.wcrs_renewals_url,
+    domain: config.wcrs_fo_link_domain,
     address: ENV.fetch("WCRS_EMAIL_HOST", nil),
     port: ENV.fetch("WCRS_EMAIL_PORT", nil),
     authentication: :plain,


### PR DESCRIPTION
This change aligns the front-office configuration with the engine by renaming the `wcrs_renewals_url` config variable to `wcrs_fo_link_domain`.
https://eaflood.atlassian.net/browse/RUBY-2294