### PR TITLE
Fix/ruby 2225 password autocomplete off

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 959abffd1974f2e1fde9aa11b308b8f85bd894b5
+  revision: fa31ce910dda2e8bbda78b8fd7cabdfe740c5aea
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -398,13 +398,13 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.17.1)
+    rubocop-capybara (2.18.0)
       rubocop (~> 1.41)
     rubocop-rails (2.19.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.19.0)
+    rubocop-rspec (2.21.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -11,13 +11,16 @@
 
       <%= f.govuk_password_field :current_password,
           label: { text: t(".labels.current_password") },
-          hint: { text: t(".labels.current_password_hint") } %>
+          hint: { text: t(".labels.current_password_hint") },
+          autocomplete: "off" %>
 
       <%= f.govuk_password_field :password,
-          label: { text: t(".labels.password") } %>
+          label: { text: t(".labels.password") },
+          autocomplete: "off" %>
 
       <%= f.govuk_password_field :password_confirmation,
-          label: { text: t(".labels.password_confirmation") } %>
+          label: { text: t(".labels.password_confirmation") },
+          autocomplete: "off" %>
 
       <%= f.govuk_submit t(".submit_button"), class: "button" %>
     <% end %>

--- a/spec/requests/certificates_spec.rb
+++ b/spec/requests/certificates_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Certificates" do
 
       it "returns a 200 status code" do
         get "/fo/registrations/#{registration.reg_identifier}/certificate"
-        expect(response.code).to eq("200")
+        expect(response).to have_http_status(:ok)
       end
 
       context "when the 'show_as_html' query string is present" do


### PR DESCRIPTION
setting autocomplete to off for password fields + updating dependencies

https://eaflood.atlassian.net/browse/RUBY-2225