### PR TITLE
Bump defra_ruby_mocks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
       notifications-ruby-client
       rails (~> 6.0)
       sprockets (~> 3.7.2)
-    defra_ruby_mocks (2.4.0)
+    defra_ruby_mocks (2.4.1)
       rails (~> 6.0)
       sprockets (~> 3.7.2)
     defra_ruby_style (0.3.0)


### PR DESCRIPTION
Use the latest version of the `defra_ruby_mocks` gem.
https://eaflood.atlassian.net/browse/RUBY-2433