### PR TITLE
RUBY-3433: Tech Debt : remove devise and cancancan gems + remove front-office users from wcr engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "wicked_pdf"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "feature/RUBY-3433-wcr-tech-debt-remove-the-devise-and-cancancan-gems-from-wcr-engine"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 41f08ab6017b9570dd0581de0e83267004c0c91b
-  branch: main
+  revision: 2d000180975e015cade9168918cabf092332a4d5
+  branch: feature/RUBY-3433-wcr-tech-debt-remove-the-devise-and-cancancan-gems-from-wcr-engine
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 2d000180975e015cade9168918cabf092332a4d5
+  revision: 35bcadd946120ae18e623024e2d74657ad7c38b3
   branch: feature/RUBY-3433-wcr-tech-debt-remove-the-devise-and-cancancan-gems-from-wcr-engine
   specs:
     waste_carriers_engine (0.0.1)


### PR DESCRIPTION
WCR - TechDebt - Remove the devise and cancancan gems from WCR engine
https://eaflood.atlassian.net/browse/RUBY-3433

- remove devise gem and related code from the engine. Move still necessary functionality over to back-office
- remove cancancan gem and related code from the engine.
- remove user model and related code and tests from the engine. Move still necessary functionality over to back-office
- update README