### PR TITLE
Release/v1.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 ## [Unreleased](https://github.com/defra/waste-carriers-front-office/tree/HEAD)
 
-[Full Changelog](https://github.com/defra/waste-carriers-front-office/compare/v1.30.0...HEAD)
+[Full Changelog](https://github.com/defra/waste-carriers-front-office/compare/v1.30.1...HEAD)
 
 **Merged pull requests:**
 
+- Bump waste\_carriers\_engine from `1bb166d` to `33cc560` [\#1632](https://github.com/DEFRA/waste-carriers-front-office/pull/1632) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump activesupport from 7.2.3 to 7.2.3.1 [\#1614](https://github.com/DEFRA/waste-carriers-front-office/pull/1614) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v1.30.1](https://github.com/defra/waste-carriers-front-office/tree/v1.30.1) (2026-04-16)
+
+[Full Changelog](https://github.com/defra/waste-carriers-front-office/compare/v1.30.0...v1.30.1)
+
+**Merged pull requests:**
+
+- Release/v1.30.1 [\#1624](https://github.com/DEFRA/waste-carriers-front-office/pull/1624) ([brujeo](https://github.com/brujeo))
 - Bump gem dependencies 2026-04-15 [\#1623](https://github.com/DEFRA/waste-carriers-front-office/pull/1623) ([brujeo](https://github.com/brujeo))
 - enabling cross-app mocks [\#1617](https://github.com/DEFRA/waste-carriers-front-office/pull/1617) ([brujeo](https://github.com/brujeo))
 - Bump waste\_carriers\_engine from `22be190` to `9379f29` [\#1616](https://github.com/DEFRA/waste-carriers-front-office/pull/1616) ([dependabot[bot]](https://github.com/apps/dependabot))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,8 +135,8 @@ GEM
     aws-eventstream (1.4.0)
     aws-healthcheck (2.0.0)
       railties (>= 3.0)
-    aws-partitions (1.1238.0)
-    aws-sdk-core (3.244.0)
+    aws-partitions (1.1246.0)
+    aws-sdk-core (3.246.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -144,10 +144,10 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.123.0)
+    aws-sdk-kms (1.124.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.219.0)
+    aws-sdk-s3 (1.221.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -219,13 +219,13 @@ GEM
       rest-client (~> 2.0)
       uk_postcode
       validates_email_format_of
-    devise (5.0.3)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
-    devise_invitable (2.0.11)
+    devise_invitable (2.0.12)
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.6.2)
@@ -239,7 +239,7 @@ GEM
     erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.1)
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
@@ -300,7 +300,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.3)
+    json (2.19.5)
     jwt (2.10.2)
       base64
     kaminari (1.2.2)
@@ -355,7 +355,7 @@ GEM
       mongoid (>= 5.0, < 9)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -495,9 +495,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.22.1)
+    rubocop-capybara (2.23.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -542,7 +542,7 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    spring (4.4.2)
+    spring (4.5.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger


### PR DESCRIPTION
Update CHANGELOG.md

Updated gems:
      - aws-partitions: 1.1238.0 -> 1.1246.0
      - aws-sdk-core: 3.244.0 -> 3.246.0
      - aws-sdk-kms: 1.123.0 -> 1.124.0
      - aws-sdk-s3: 1.219.0 -> 1.221.0
      - devise: 5.0.3 -> 5.0.4
      - devise_invitable: 2.0.11 -> 2.0.12
      - factory_bot: 6.5.6 -> 6.6.0
      - json: 2.19.3 -> 2.19.5
      - net-imap: 0.6.3 -> 0.6.4
      - rubocop-capybara: 2.22.1 -> 2.23.0
      - rubocop: ~> 1.72, >= 1.72.1 -> ~> 1.81
      - spring: 4.4.2 -> 4.5.0